### PR TITLE
feat(publish): Implement Phase 5 Publish Agent

### DIFF
--- a/src/game_workflow/agents/__init__.py
+++ b/src/game_workflow/agents/__init__.py
@@ -10,7 +10,25 @@ This module contains the specialized agents for each workflow phase:
 from game_workflow.agents.base import BaseAgent
 from game_workflow.agents.build import BuildAgent
 from game_workflow.agents.design import DesignAgent
-from game_workflow.agents.publish import PublishAgent
+from game_workflow.agents.publish import (
+    ControlMapping,
+    Credit,
+    FeatureHighlight,
+    GitHubRelease,
+    ItchioClassification,
+    ItchioVisibility,
+    PublishAgent,
+    PublishConfig,
+    PublishOutput,
+    ReleaseArtifact,
+    ReleaseType,
+    Screenshot,
+    StorePageContent,
+    TechnicalDetails,
+    VersionInfo,
+    get_publish_output_schema,
+    get_store_page_schema,
+)
 from game_workflow.agents.qa import QAAgent
 from game_workflow.agents.schemas import (
     ComplexityLevel,
@@ -25,12 +43,28 @@ __all__ = [
     "BaseAgent",
     "BuildAgent",
     "ComplexityLevel",
+    "ControlMapping",
+    "Credit",
     "DesignAgent",
     "DesignOutput",
+    "FeatureHighlight",
     "GameConcept",
     "GameDesignDocument",
     "GameEngine",
+    "GitHubRelease",
+    "ItchioClassification",
+    "ItchioVisibility",
     "PublishAgent",
+    "PublishConfig",
+    "PublishOutput",
     "QAAgent",
+    "ReleaseArtifact",
+    "ReleaseType",
+    "Screenshot",
+    "StorePageContent",
+    "TechnicalDetails",
     "TechnicalSpecification",
+    "VersionInfo",
+    "get_publish_output_schema",
+    "get_store_page_schema",
 ]

--- a/src/game_workflow/agents/publish.py
+++ b/src/game_workflow/agents/publish.py
@@ -1,46 +1,828 @@
 """Publish agent for itch.io release preparation.
 
 This agent prepares game builds for publishing to itch.io,
-including generating store pages and handling uploads.
+including generating store pages, marketing copy, and handling uploads.
 """
 
-from pathlib import Path
-from typing import Any
+from __future__ import annotations
 
-from game_workflow.agents.base import BaseAgent
+import json
+import logging
+import zipfile
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+from anthropic import Anthropic
+from anthropic.types import Message, TextBlock
+from pydantic import BaseModel, Field
+
+from game_workflow.agents.base import DEFAULT_MODEL, BaseAgent
+from game_workflow.agents.schemas import GameDesignDocument
+from game_workflow.orchestrator.exceptions import AgentError
+from game_workflow.utils.templates import render_itchio_page
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from game_workflow.orchestrator.state import WorkflowState
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Schemas for Publish Output
+# =============================================================================
+
+
+class ReleaseType(str, Enum):
+    """Types of releases."""
+
+    INITIAL = "initial"
+    UPDATE = "update"
+    PATCH = "patch"
+    BETA = "beta"
+    DEMO = "demo"
+
+
+class ItchioClassification(str, Enum):
+    """itch.io game classifications."""
+
+    GAME = "game"
+    TOOL = "tool"
+    GAME_ASSETS = "game_assets"
+    COMIC = "comic"
+    BOOK = "book"
+    SOUNDTRACK = "soundtrack"
+    PHYSICAL_GAME = "physical_game"
+    OTHER = "other"
+
+
+class ItchioVisibility(str, Enum):
+    """itch.io project visibility options."""
+
+    DRAFT = "draft"
+    RESTRICTED = "restricted"
+    PUBLIC = "public"
+
+
+class ControlMapping(BaseModel):
+    """A control/input mapping for the game."""
+
+    input: str = Field(..., description="The input (e.g., 'Arrow Keys', 'WASD')")
+    action: str = Field(..., description="What the input does")
+
+
+class FeatureHighlight(BaseModel):
+    """A highlighted feature of the game."""
+
+    name: str = Field(..., description="Feature name")
+    description: str = Field(..., description="Feature description")
+
+
+class Screenshot(BaseModel):
+    """A screenshot entry."""
+
+    filename: str = Field(..., description="Screenshot filename")
+    url: str = Field(default="", description="URL or path to screenshot")
+    caption: str = Field(..., description="Screenshot caption/alt text")
+    description: str | None = Field(default=None, description="Optional longer description")
+
+
+class Credit(BaseModel):
+    """A credit entry."""
+
+    role: str = Field(..., description="Role (e.g., 'Developer', 'Art')")
+    name: str = Field(..., description="Name of the person/entity")
+    link: str | None = Field(default=None, description="Optional link")
+
+
+class TechnicalDetails(BaseModel):
+    """Technical details for the store page."""
+
+    resolution: str = Field(default="800x600", description="Game resolution")
+    browser_support: list[str] = Field(
+        default_factory=lambda: ["Chrome", "Firefox", "Safari", "Edge"],
+        description="Supported browsers",
+    )
+    input_methods: list[str] = Field(
+        default_factory=lambda: ["Keyboard", "Mouse"],
+        description="Supported input methods",
+    )
+    save_support: bool = Field(default=False, description="Whether game supports saves")
+    audio: bool = Field(default=True, description="Whether game has audio")
+
+
+class VersionInfo(BaseModel):
+    """Version information for the release."""
+
+    current: str = Field(default="1.0.0", description="Current version")
+    changelog: list[dict[str, str]] = Field(default_factory=list, description="Changelog entries")
+
+
+class SupportInfo(BaseModel):
+    """Support information for the store page."""
+
+    message: str = Field(default="", description="Support message")
+    links: list[dict[str, str]] = Field(default_factory=list, description="Support links")
+
+
+class StorePageContent(BaseModel):
+    """Complete itch.io store page content.
+
+    This is the structured output from marketing copy generation.
+    """
+
+    # Required fields
+    title: str = Field(..., description="Game title")
+    tagline: str = Field(..., description="Short tagline (1 sentence)")
+    description: str = Field(..., description="Main description (2-3 paragraphs)")
+    features: list[str] = Field(..., description="List of key features")
+    controls: list[ControlMapping] = Field(..., description="Control mappings")
+
+    # Optional content
+    story: str | None = Field(default=None, description="Story/narrative description")
+    tips: list[str] = Field(default_factory=list, description="Tips for players")
+    highlights: list[FeatureHighlight] = Field(
+        default_factory=list, description="Feature highlights"
+    )
+    screenshots: list[Screenshot] = Field(default_factory=list, description="Screenshots")
+    technical_details: TechnicalDetails = Field(
+        default_factory=TechnicalDetails, description="Technical details"
+    )
+
+    # Metadata
+    tags: list[str] = Field(default_factory=list, description="itch.io tags")
+    engine: str = Field(default="Phaser.js", description="Game engine used")
+
+    # Credits
+    credits: list[Credit] = Field(default_factory=list, description="Credits")
+    acknowledgments: str | None = Field(default=None, description="Acknowledgments")
+
+    # Version
+    version: VersionInfo = Field(default_factory=VersionInfo, description="Version info")
+
+    # Support
+    support: SupportInfo | None = Field(default=None, description="Support info")
+
+
+class ReleaseArtifact(BaseModel):
+    """A release artifact (build file)."""
+
+    name: str = Field(..., description="Artifact name")
+    path: str = Field(..., description="Path to artifact")
+    size_bytes: int = Field(default=0, description="File size in bytes")
+    checksum: str | None = Field(default=None, description="SHA256 checksum")
+
+
+class GitHubRelease(BaseModel):
+    """GitHub release information."""
+
+    tag: str = Field(..., description="Git tag (e.g., 'v1.0.0')")
+    name: str = Field(..., description="Release name")
+    body: str = Field(..., description="Release notes markdown")
+    prerelease: bool = Field(default=False, description="Is this a prerelease")
+    draft: bool = Field(default=True, description="Is this a draft release")
+
+
+class PublishOutput(BaseModel):
+    """Complete output from the Publish Agent."""
+
+    # Store page
+    store_page: StorePageContent = Field(..., description="Store page content")
+    store_page_markdown: str = Field(..., description="Rendered store page markdown")
+
+    # Artifacts
+    artifacts: list[ReleaseArtifact] = Field(..., description="Release artifacts")
+    zip_path: str | None = Field(default=None, description="Path to the zip archive")
+
+    # GitHub release (optional, may be created by MCP server)
+    github_release: GitHubRelease | None = Field(default=None, description="GitHub release info")
+
+    # itch.io settings
+    itchio_project: str | None = Field(default=None, description="itch.io project slug")
+    classification: ItchioClassification = Field(
+        default=ItchioClassification.GAME, description="itch.io classification"
+    )
+    visibility: ItchioVisibility = Field(
+        default=ItchioVisibility.DRAFT, description="Initial visibility"
+    )
+
+    # Metadata
+    release_type: ReleaseType = Field(..., description="Type of release")
+    version: str = Field(default="1.0.0", description="Version string")
+    prepared_at: datetime = Field(default_factory=datetime.now, description="Preparation time")
+
+
+# =============================================================================
+# Dataclasses for internal use
+# =============================================================================
+
+
+@dataclass
+class PublishConfig:
+    """Configuration for the publish agent."""
+
+    project_name: str
+    version: str = "1.0.0"
+    release_type: ReleaseType = ReleaseType.INITIAL
+    visibility: ItchioVisibility = ItchioVisibility.DRAFT
+    itchio_username: str | None = None
+    github_repo: str | None = None
+    create_github_release: bool = False
+    screenshots_dir: Path | None = None
+    additional_tags: list[str] = field(default_factory=list)
+
+
+# =============================================================================
+# System Prompts
+# =============================================================================
+
+
+MARKETING_COPY_PROMPT = """You are an expert game marketer and copywriter creating content for an itch.io store page.
+
+Based on the following Game Design Document, create compelling marketing copy that will attract players.
+Your copy should:
+1. Be engaging and exciting without being hyperbolic
+2. Clearly communicate what makes this game unique
+3. Be honest about the game's scope (this is an indie/hobby game)
+4. Include practical information players need
+
+Game Design Document:
+{gdd}
+
+Generate store page content following this JSON schema:
+{schema}
+
+Important:
+- The tagline should be punchy and memorable (under 80 characters)
+- The description should hook players in the first paragraph
+- Features should be specific and compelling
+- Include 5-10 relevant itch.io tags (e.g., "puzzle", "platformer", "retro", "casual")
+- Controls should be clear and complete
+- If the game has a narrative, include a brief story tease
+"""
+
+
+# =============================================================================
+# PublishAgent Implementation
+# =============================================================================
 
 
 class PublishAgent(BaseAgent):
     """Agent for publishing games to itch.io.
 
     This agent prepares releases including:
-    - Generating store page content
-    - Creating screenshots and thumbnails
-    - Uploading via butler CLI
+    - Generating store page content from GDD
+    - Creating marketing copy
+    - Packaging build artifacts
+    - Preparing GitHub releases
+    - Setting up itch.io project configuration
     """
+
+    def __init__(
+        self,
+        model: str = DEFAULT_MODEL,
+        state: WorkflowState | None = None,
+        output_dir: Path | None = None,
+    ) -> None:
+        """Initialize the publish agent.
+
+        Args:
+            model: The Claude model to use.
+            state: The workflow state for context.
+            output_dir: Directory to save publish artifacts.
+        """
+        super().__init__(model=model, state=state)
+        self.output_dir = output_dir
+        self._client: Anthropic | None = None
 
     @property
     def name(self) -> str:
         """Get the agent's name."""
         return "PublishAgent"
 
+    @property
+    def client(self) -> Anthropic:
+        """Get or create the Anthropic client.
+
+        Returns:
+            Configured Anthropic client.
+
+        Raises:
+            AgentError: If API key is not configured.
+        """
+        if self._client is None:
+            if not self.api_key:
+                raise AgentError(
+                    self.name,
+                    "Anthropic API key not configured. Set ANTHROPIC_API_KEY.",
+                )
+            self._client = Anthropic(api_key=self.api_key)
+        return self._client
+
     async def run(
         self,
         game_dir: Path,
-        gdd_path: Path,
-        project_name: str,
-        **kwargs: Any,
+        gdd_path: Path | None = None,
+        gdd_data: dict[str, Any] | None = None,
+        config: PublishConfig | None = None,
+        **kwargs: Any,  # noqa: ARG002
     ) -> dict[str, Any]:
-        """Publish a game to itch.io.
+        """Prepare a game for publishing to itch.io.
 
         Args:
-            game_dir: Directory containing the built game.
-            gdd_path: Path to the GDD for store page content.
-            project_name: The itch.io project name.
+            game_dir: Directory containing the built game (dist folder).
+            gdd_path: Path to the GDD JSON file.
+            gdd_data: GDD data as dictionary (alternative to gdd_path).
+            config: Publishing configuration.
             **kwargs: Additional arguments.
 
         Returns:
-            Dict containing publish results and URLs.
+            Dict containing:
+                - status: "success" or "failed"
+                - store_page: Store page content
+                - artifacts: List of release artifacts
+                - publish_output: Full PublishOutput object
+
+        Raises:
+            AgentError: If publishing preparation fails.
         """
-        # TODO: Implement itch.io publishing
-        raise NotImplementedError("Game publishing not yet implemented")
+        self.log_info("Starting publish preparation...")
+
+        # Validate inputs
+        if not game_dir.exists():
+            raise AgentError(self.name, f"Game directory not found: {game_dir}")
+
+        # Load GDD
+        gdd = await self._load_gdd(gdd_path, gdd_data)
+
+        # Create default config if not provided
+        if config is None:
+            project_slug = gdd.title.lower().replace(" ", "-").replace("'", "")
+            config = PublishConfig(project_name=project_slug)
+
+        # Setup output directory
+        if self.output_dir is None:
+            self.output_dir = game_dir.parent / "publish"
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Step 1: Generate marketing copy
+        self.log_info("Generating marketing copy...")
+        store_page = await self._generate_marketing_copy(gdd, config)
+
+        # Step 2: Collect screenshots (if available)
+        if config.screenshots_dir and config.screenshots_dir.exists():
+            store_page = self._add_screenshots(store_page, config.screenshots_dir)
+
+        # Step 3: Render store page markdown
+        self.log_info("Rendering store page...")
+        store_page_md = self._render_store_page(store_page)
+
+        # Step 4: Package build artifacts
+        self.log_info("Packaging build artifacts...")
+        artifacts, zip_path = await self._package_artifacts(game_dir, config)
+
+        # Step 5: Prepare GitHub release (metadata only)
+        github_release = None
+        if config.create_github_release:
+            github_release = self._prepare_github_release(gdd, config, store_page)
+
+        # Step 6: Create complete output
+        output = PublishOutput(
+            store_page=store_page,
+            store_page_markdown=store_page_md,
+            artifacts=artifacts,
+            zip_path=str(zip_path) if zip_path else None,
+            github_release=github_release,
+            itchio_project=config.project_name,
+            visibility=config.visibility,
+            release_type=config.release_type,
+            version=config.version,
+        )
+
+        # Step 7: Save artifacts
+        artifacts_dict = await self._save_artifacts(output)
+
+        self.log_info("Publish preparation complete")
+
+        return {
+            "status": "success",
+            "store_page": store_page.model_dump(),
+            "store_page_markdown": store_page_md,
+            "artifacts": [a.model_dump() for a in artifacts],
+            "zip_path": str(zip_path) if zip_path else None,
+            "github_release": github_release.model_dump() if github_release else None,
+            "saved_files": artifacts_dict,
+            "publish_output": output.model_dump(mode="json"),
+        }
+
+    async def _load_gdd(
+        self, gdd_path: Path | None, gdd_data: dict[str, Any] | None
+    ) -> GameDesignDocument:
+        """Load GDD from path or data.
+
+        Args:
+            gdd_path: Path to GDD JSON file.
+            gdd_data: GDD data as dictionary.
+
+        Returns:
+            Validated GameDesignDocument.
+
+        Raises:
+            AgentError: If GDD cannot be loaded.
+        """
+        if gdd_data is not None:
+            return GameDesignDocument.model_validate(gdd_data)
+
+        if gdd_path is None:
+            raise AgentError(self.name, "Either gdd_path or gdd_data must be provided")
+
+        if not gdd_path.exists():
+            raise AgentError(self.name, f"GDD file not found: {gdd_path}")
+
+        try:
+            with gdd_path.open() as f:
+                data: dict[str, Any] = json.load(f)
+            return GameDesignDocument.model_validate(data)
+        except json.JSONDecodeError as e:
+            raise AgentError(self.name, f"Failed to parse GDD JSON: {e}", cause=e) from e
+        except Exception as e:
+            raise AgentError(self.name, f"Failed to load GDD: {e}", cause=e) from e
+
+    async def _generate_marketing_copy(
+        self, gdd: GameDesignDocument, config: PublishConfig
+    ) -> StorePageContent:
+        """Generate marketing copy from GDD.
+
+        Args:
+            gdd: The Game Design Document.
+            config: Publishing configuration.
+
+        Returns:
+            Store page content.
+        """
+        schema = StorePageContent.model_json_schema()
+
+        # Create a summary of the GDD for the prompt
+        gdd_summary = self._summarize_gdd(gdd)
+
+        system_prompt = MARKETING_COPY_PROMPT.format(
+            gdd=gdd_summary,
+            schema=json.dumps(schema, indent=2),
+        )
+
+        response = self.client.messages.create(
+            model=self.model,
+            max_tokens=8192,
+            messages=[
+                {
+                    "role": "user",
+                    "content": f"Create itch.io store page content for '{gdd.title}'. Return as JSON.",
+                }
+            ],
+            system=system_prompt,
+        )
+
+        text = self._extract_text(response)
+        page_data = self._parse_json_response(text)
+
+        # Set defaults and merge with config
+        page_data["title"] = gdd.title
+        page_data["engine"] = gdd.engine.value.capitalize()
+
+        # Add additional tags from config
+        if config.additional_tags:
+            existing_tags = page_data.get("tags", [])
+            page_data["tags"] = list(set(existing_tags + config.additional_tags))
+
+        # Set version
+        page_data["version"] = {"current": config.version, "changelog": []}
+
+        # Extract technical details from GDD
+        page_data["technical_details"] = {
+            "resolution": gdd.resolution,
+            "browser_support": gdd.supported_platforms,
+            "input_methods": gdd.input_methods,
+            "save_support": False,  # Default
+            "audio": bool(gdd.sound_effects or gdd.music_description),
+        }
+
+        return StorePageContent.model_validate(page_data)
+
+    def _summarize_gdd(self, gdd: GameDesignDocument) -> str:
+        """Create a summary of the GDD for the marketing prompt.
+
+        Args:
+            gdd: The Game Design Document.
+
+        Returns:
+            Summary string.
+        """
+        mechanics = ", ".join(m.name for m in gdd.core_mechanics[:5])
+        features = "\n".join(f"- {f}" for f in gdd.mvp_features[:10])
+        usps = "\n".join(f"- {u}" for u in gdd.unique_selling_points[:5])
+
+        return f"""Title: {gdd.title}
+Genre: {gdd.genre}
+Visual Style: {gdd.visual_style}
+Target Audience: {gdd.target_audience}
+
+Concept Summary:
+{gdd.concept_summary}
+
+Core Mechanics: {mechanics}
+
+Core Game Loop:
+{gdd.core_game_loop}
+
+Win Condition: {gdd.win_condition}
+Loss Condition: {gdd.loss_condition}
+
+Setting: {gdd.setting}
+Narrative: {gdd.narrative}
+
+Unique Selling Points:
+{usps}
+
+Key Features:
+{features}
+"""
+
+    def _add_screenshots(
+        self, store_page: StorePageContent, screenshots_dir: Path
+    ) -> StorePageContent:
+        """Add screenshots to store page content.
+
+        Args:
+            store_page: Existing store page content.
+            screenshots_dir: Directory containing screenshots.
+
+        Returns:
+            Updated store page content with screenshots.
+        """
+        screenshots: list[Screenshot] = []
+
+        # Look for common screenshot formats
+        for pattern in ["*.png", "*.jpg", "*.jpeg", "*.gif", "*.webp"]:
+            for img_path in screenshots_dir.glob(pattern):
+                screenshot = Screenshot(
+                    filename=img_path.name,
+                    url=str(img_path),
+                    caption=img_path.stem.replace("-", " ").replace("_", " ").title(),
+                )
+                screenshots.append(screenshot)
+
+        # Sort by filename for consistent ordering
+        screenshots.sort(key=lambda s: s.filename)
+
+        # Update store page
+        store_page.screenshots = screenshots[:10]  # Limit to 10 screenshots
+
+        return store_page
+
+    def _render_store_page(self, store_page: StorePageContent) -> str:
+        """Render the store page to markdown.
+
+        Args:
+            store_page: Store page content.
+
+        Returns:
+            Rendered markdown string.
+        """
+        # Convert to dict for template rendering
+        page_data = store_page.model_dump()
+
+        # Convert controls to list of dicts for template
+        if page_data.get("controls"):
+            page_data["controls"] = [
+                {"input": c["input"], "action": c["action"]} for c in page_data["controls"]
+            ]
+
+        return render_itchio_page(page_data)
+
+    async def _package_artifacts(
+        self, game_dir: Path, config: PublishConfig
+    ) -> tuple[list[ReleaseArtifact], Path | None]:
+        """Package build artifacts for release.
+
+        Args:
+            game_dir: Directory containing the built game.
+            config: Publishing configuration.
+
+        Returns:
+            Tuple of (list of artifacts, path to zip file).
+        """
+        artifacts: list[ReleaseArtifact] = []
+
+        # Find all files in the game directory
+        for file_path in game_dir.rglob("*"):
+            if file_path.is_file():
+                artifact = ReleaseArtifact(
+                    name=file_path.name,
+                    path=str(file_path),
+                    size_bytes=file_path.stat().st_size,
+                )
+                artifacts.append(artifact)
+
+        # Create a zip archive
+        zip_name = f"{config.project_name}-v{config.version}.zip"
+        zip_path = self.output_dir / zip_name if self.output_dir else game_dir.parent / zip_name
+
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for file_path in game_dir.rglob("*"):
+                if file_path.is_file():
+                    arcname = file_path.relative_to(game_dir)
+                    zf.write(file_path, arcname)
+
+        # Add the zip as an artifact
+        zip_artifact = ReleaseArtifact(
+            name=zip_name,
+            path=str(zip_path),
+            size_bytes=zip_path.stat().st_size,
+        )
+        artifacts.append(zip_artifact)
+
+        self.log_info(f"Created zip archive: {zip_path} ({zip_artifact.size_bytes} bytes)")
+
+        return artifacts, zip_path
+
+    def _prepare_github_release(
+        self,
+        gdd: GameDesignDocument,
+        config: PublishConfig,
+        store_page: StorePageContent,
+    ) -> GitHubRelease:
+        """Prepare GitHub release metadata.
+
+        Args:
+            gdd: The Game Design Document.
+            config: Publishing configuration.
+            store_page: Store page content for release notes.
+
+        Returns:
+            GitHub release information.
+        """
+        tag = f"v{config.version}"
+
+        # Create release notes
+        features_list = "\n".join(f"- {f}" for f in store_page.features[:10])
+
+        body = f"""# {gdd.title} {tag}
+
+{store_page.tagline}
+
+## What's New
+
+This is the {"initial release" if config.release_type == ReleaseType.INITIAL else config.release_type.value} of {gdd.title}.
+
+## Features
+
+{features_list}
+
+## Play Now
+
+[Play on itch.io](https://itch.io)
+
+---
+
+Built with {gdd.engine.value.capitalize()} | Generated by Game Workflow Automation
+"""
+
+        return GitHubRelease(
+            tag=tag,
+            name=f"{gdd.title} {tag}",
+            body=body,
+            prerelease=config.release_type in (ReleaseType.BETA, ReleaseType.DEMO),
+            draft=True,  # Always create as draft for review
+        )
+
+    async def _save_artifacts(self, output: PublishOutput) -> dict[str, str]:
+        """Save publish artifacts to files.
+
+        Args:
+            output: The complete publish output.
+
+        Returns:
+            Dictionary mapping artifact names to file paths.
+        """
+        if self.output_dir is None:
+            raise AgentError(self.name, "Output directory not set")
+
+        saved: dict[str, str] = {}
+
+        # Save store page markdown
+        store_page_path = self.output_dir / "store-page.md"
+        store_page_path.write_text(output.store_page_markdown)
+        saved["store_page_md"] = str(store_page_path)
+
+        # Save store page JSON
+        store_page_json_path = self.output_dir / "store-page.json"
+        with store_page_json_path.open("w") as f:
+            json.dump(output.store_page.model_dump(mode="json"), f, indent=2, default=str)
+        saved["store_page_json"] = str(store_page_json_path)
+
+        # Save complete publish output
+        output_path = self.output_dir / "publish-output.json"
+        with output_path.open("w") as f:
+            json.dump(output.model_dump(mode="json"), f, indent=2, default=str)
+        saved["publish_output"] = str(output_path)
+
+        # Save GitHub release notes if present
+        if output.github_release:
+            release_notes_path = self.output_dir / "release-notes.md"
+            release_notes_path.write_text(output.github_release.body)
+            saved["release_notes"] = str(release_notes_path)
+
+        # Add artifacts to state if available
+        if self.state:
+            for name, path in saved.items():
+                self.add_artifact(name, path)
+
+        self.log_debug(f"Saved {len(saved)} publish artifacts to {self.output_dir}")
+
+        return saved
+
+    def _extract_text(self, response: Message) -> str:
+        """Extract text content from an API response.
+
+        Args:
+            response: The API response message.
+
+        Returns:
+            The text content, or empty string if no text block found.
+        """
+        if not response.content:
+            return ""
+        for block in response.content:
+            if isinstance(block, TextBlock):
+                return block.text
+        return ""
+
+    def _parse_json_response(self, text: str) -> dict[str, Any]:
+        """Parse JSON from a model response.
+
+        Handles cases where the JSON might be wrapped in markdown code blocks.
+
+        Args:
+            text: The response text.
+
+        Returns:
+            Parsed JSON as dictionary.
+
+        Raises:
+            AgentError: If JSON parsing fails.
+        """
+        # Strip markdown code blocks if present
+        text = text.strip()
+        if text.startswith("```"):
+            first_newline = text.find("\n")
+            if first_newline != -1:
+                text = text[first_newline + 1 :]
+            if text.endswith("```"):
+                text = text[:-3]
+            text = text.strip()
+
+        try:
+            result: dict[str, Any] = json.loads(text)
+            return result
+        except json.JSONDecodeError as e:
+            # Try to find JSON in the response
+            start = text.find("{")
+            end = text.rfind("}") + 1
+            if start != -1 and end > start:
+                try:
+                    result = json.loads(text[start:end])
+                    return result
+                except json.JSONDecodeError:
+                    pass
+
+            raise AgentError(
+                self.name,
+                f"Failed to parse JSON response: {e}",
+                cause=e,
+            ) from e
+
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+
+def get_store_page_schema() -> dict[str, Any]:
+    """Get JSON Schema for StorePageContent.
+
+    Returns:
+        JSON Schema dictionary.
+    """
+    return StorePageContent.model_json_schema()
+
+
+def get_publish_output_schema() -> dict[str, Any]:
+    """Get JSON Schema for PublishOutput.
+
+    Returns:
+        JSON Schema dictionary.
+    """
+    return PublishOutput.model_json_schema()

--- a/src/game_workflow/utils/templates.py
+++ b/src/game_workflow/utils/templates.py
@@ -132,6 +132,18 @@ def render_concept(concept_data: dict[str, Any]) -> str:
     return render_template("concept-template.md", concept_data)
 
 
+def render_itchio_page(page_data: dict[str, Any]) -> str:
+    """Render an itch.io store page from structured data.
+
+    Args:
+        page_data: Dictionary containing itch.io page fields.
+
+    Returns:
+        Rendered itch.io page as markdown string.
+    """
+    return render_template("itchio-page.md", page_data)
+
+
 def get_scaffold_path(engine: str) -> Path:
     """Get the path to a project scaffold.
 

--- a/templates/itchio-page.md
+++ b/templates/itchio-page.md
@@ -1,23 +1,146 @@
-# {{GAME_TITLE}}
+# {{ title }}
 
-{{TAGLINE}}
-
-## About This Game
-
-{{DESCRIPTION}}
-
-## How to Play
-
-{{CONTROLS}}
-
-## Features
-
-{{FEATURES}}
-
-## Credits
-
-{{CREDITS}}
+{{ tagline }}
 
 ---
 
-Made with {{ENGINE}}
+## About This Game
+
+{{ description }}
+
+{% if story %}
+### The Story
+
+{{ story }}
+{% endif %}
+
+---
+
+## How to Play
+
+{% if controls is iterable and controls is not string %}
+{% for control in controls %}
+- **{{ control.input }}**: {{ control.action }}
+{% endfor %}
+{% else %}
+{{ controls }}
+{% endif %}
+
+{% if tips %}
+### Tips for Success
+
+{% for tip in tips %}
+- {{ tip }}
+{% endfor %}
+{% endif %}
+
+---
+
+## Features
+
+{% for feature in features %}
+- {{ feature }}
+{% endfor %}
+
+{% if highlights %}
+### Highlights
+
+{% for highlight in highlights %}
+- **{{ highlight.name }}**: {{ highlight.description }}
+{% endfor %}
+{% endif %}
+
+---
+
+{% if screenshots %}
+## Screenshots
+
+{% for screenshot in screenshots %}
+![{{ screenshot.caption }}]({{ screenshot.url }})
+{% if screenshot.description %}
+*{{ screenshot.description }}*
+{% endif %}
+
+{% endfor %}
+{% endif %}
+
+---
+
+{% if technical_details %}
+## Technical Details
+
+{% if technical_details.resolution %}
+- **Resolution**: {{ technical_details.resolution }}
+{% endif %}
+{% if technical_details.browser_support %}
+- **Browser Support**: {{ technical_details.browser_support | join(", ") }}
+{% endif %}
+{% if technical_details.input_methods %}
+- **Input Methods**: {{ technical_details.input_methods | join(", ") }}
+{% endif %}
+{% if technical_details.save_support is defined %}
+- **Save Support**: {{ "Yes" if technical_details.save_support else "No" }}
+{% endif %}
+{% if technical_details.audio is defined %}
+- **Audio**: {{ "Yes - sound effects and music" if technical_details.audio else "No audio" }}
+{% endif %}
+
+{% endif %}
+
+---
+
+{% if credits %}
+## Credits
+
+{% for credit in credits %}
+- **{{ credit.role }}**: {{ credit.name }}{% if credit.link %} ([link]({{ credit.link }})){% endif %}
+
+{% endfor %}
+{% endif %}
+
+{% if acknowledgments %}
+### Special Thanks
+
+{{ acknowledgments }}
+{% endif %}
+
+---
+
+{% if version %}
+## Version History
+
+{% if version.current %}
+**Current Version**: {{ version.current }}
+{% endif %}
+
+{% if version.changelog %}
+### Changelog
+
+{% for entry in version.changelog %}
+- **{{ entry.version }}** ({{ entry.date }}): {{ entry.description }}
+{% endfor %}
+{% endif %}
+{% endif %}
+
+---
+
+{% if support %}
+## Support
+
+{{ support.message }}
+
+{% if support.links %}
+{% for link in support.links %}
+- [{{ link.label }}]({{ link.url }})
+{% endfor %}
+{% endif %}
+{% endif %}
+
+---
+
+Made with {{ engine | default("Phaser.js") }}
+
+{% if tags %}
+---
+*Tags: {{ tags | join(", ") }}*
+{% endif %}

--- a/tests/unit/test_publish_agent.py
+++ b/tests/unit/test_publish_agent.py
@@ -1,0 +1,875 @@
+"""Tests for the PublishAgent module."""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from anthropic.types import Message, TextBlock, Usage
+
+from game_workflow.agents.publish import (
+    ControlMapping,
+    Credit,
+    FeatureHighlight,
+    GitHubRelease,
+    ItchioClassification,
+    ItchioVisibility,
+    PublishAgent,
+    PublishConfig,
+    PublishOutput,
+    ReleaseArtifact,
+    ReleaseType,
+    Screenshot,
+    StorePageContent,
+    TechnicalDetails,
+    VersionInfo,
+    get_publish_output_schema,
+    get_store_page_schema,
+)
+from game_workflow.orchestrator.exceptions import AgentError
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# =============================================================================
+# Sample Data Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def sample_gdd_data() -> dict[str, Any]:
+    """Provide sample GDD data for testing."""
+    return {
+        "title": "Time Twist",
+        "concept_summary": "A mind-bending puzzle platformer where you control time itself.",
+        "genre": "Puzzle Platformer",
+        "platform": "Web (HTML5)",
+        "target_audience": "Puzzle game enthusiasts aged 16-35",
+        "unique_selling_points": [
+            "Multiple simultaneous timelines",
+            "Paradox-based puzzle mechanics",
+            "Beautiful temporal visual effects",
+        ],
+        "core_game_loop": "Enter level -> Solve puzzle using time mechanics -> Complete level -> Unlock next",
+        "core_mechanics": [
+            {
+                "name": "Time Rewind",
+                "description": "Player can hold R to rewind time up to 10 seconds",
+                "controls": "R key",
+            },
+            {
+                "name": "Temporal Clone",
+                "description": "Press C to create a clone that replays actions",
+                "controls": "C key",
+            },
+        ],
+        "player_actions": [
+            {"name": "Move", "description": "Arrow keys to move left/right"},
+            {"name": "Jump", "description": "Space to jump"},
+        ],
+        "win_condition": "Complete all 20 levels",
+        "loss_condition": "No death, puzzles reset on failure",
+        "progression_system": "Linear progression through increasingly complex levels",
+        "difficulty_curve": "Gentle learning curve",
+        "setting": "An ethereal void between moments in time",
+        "narrative": "You are a temporal guardian who must fix broken timelines",
+        "levels": [
+            {
+                "name": "Tutorial",
+                "description": "Introduction to basic movement",
+                "objectives": "Reach the exit door",
+            },
+        ],
+        "visual_style": "Minimalist pixel art with glowing neon time effects",
+        "art_direction": "16x16 pixel sprites",
+        "color_palette": [
+            {"name": "Background", "hex": "#0a0a0f", "usage": "Main background"},
+        ],
+        "audio_style": "Ambient electronic",
+        "sound_effects": [
+            {"name": "time_rewind", "description": "Whooshing reverse sound"},
+        ],
+        "music_description": "Ambient electronic tracks",
+        "hud_elements": [
+            {"name": "Time Meter", "description": "Shows available rewind time"},
+        ],
+        "menu_flow": "Main Menu -> Level Select -> Play",
+        "ui_style_guide": "Minimal UI",
+        "engine": "phaser",
+        "resolution": "800x600",
+        "target_fps": 60,
+        "max_load_time": "< 3 seconds",
+        "memory_budget": "< 100MB",
+        "supported_platforms": ["Chrome", "Firefox", "Safari", "Edge"],
+        "input_methods": ["Keyboard", "Mouse"],
+        "mvp_features": [
+            "Basic movement and jumping",
+            "Time rewind mechanic",
+            "5 tutorial levels",
+        ],
+        "nice_to_have_features": ["Temporal clone mechanic"],
+        "future_features": ["Level editor"],
+        "out_of_scope": ["Multiplayer"],
+        "inspiration_games": [
+            {"name": "Braid", "relevance": "Time manipulation puzzles"},
+        ],
+        "art_references": ["Hyper Light Drifter"],
+        "technical_references": ["Phaser 3 documentation"],
+        "sprite_assets": [
+            {"name": "player", "dimensions": "16x16", "description": "Player character"},
+        ],
+        "audio_assets": [
+            {"name": "bgm_main", "format": "mp3", "description": "Main music"},
+        ],
+        "implementation_notes": "Focus on smooth time rewind first",
+    }
+
+
+@pytest.fixture
+def sample_store_page_data() -> dict[str, Any]:
+    """Provide sample store page data for testing."""
+    return {
+        "title": "Time Twist",
+        "tagline": "Bend time, solve puzzles, master the paradox.",
+        "description": "A mind-bending puzzle platformer where you control time itself. Rewind mistakes, create temporal clones, and solve increasingly complex puzzles across 20 hand-crafted levels.",
+        "features": [
+            "Time rewind mechanic - undo your mistakes",
+            "Temporal clones that replay your actions",
+            "20 challenging puzzle levels",
+            "Beautiful minimalist pixel art",
+        ],
+        "controls": [
+            {"input": "Arrow Keys", "action": "Move left/right"},
+            {"input": "Space", "action": "Jump"},
+            {"input": "R", "action": "Rewind time"},
+        ],
+        "story": "You are a temporal guardian tasked with fixing broken timelines.",
+        "tips": [
+            "Use rewind liberally - there's no penalty",
+            "Watch your clone carefully to time jumps",
+        ],
+        "tags": ["puzzle", "platformer", "time-manipulation", "pixel-art", "indie"],
+        "engine": "Phaser",
+    }
+
+
+@pytest.fixture
+def sample_api_response() -> Message:
+    """Create a sample API response with store page content."""
+    store_page_json = json.dumps(
+        {
+            "title": "Time Twist",
+            "tagline": "Bend time, solve puzzles, master the paradox.",
+            "description": "A mind-bending puzzle platformer where you control time itself.",
+            "features": [
+                "Time rewind mechanic",
+                "Temporal clones",
+                "20 puzzle levels",
+            ],
+            "controls": [
+                {"input": "Arrow Keys", "action": "Move"},
+                {"input": "Space", "action": "Jump"},
+            ],
+            "tags": ["puzzle", "platformer", "indie"],
+        }
+    )
+
+    return Message(
+        id="msg_test",
+        type="message",
+        role="assistant",
+        content=[TextBlock(type="text", text=store_page_json)],
+        model="claude-sonnet-4-5-20250929",
+        stop_reason="end_turn",
+        stop_sequence=None,
+        usage=Usage(input_tokens=100, output_tokens=200),
+    )
+
+
+@pytest.fixture
+def game_dir(tmp_path: Path) -> Path:
+    """Create a temporary game directory with sample files."""
+    game_path = tmp_path / "dist"
+    game_path.mkdir()
+
+    # Create sample game files
+    (game_path / "index.html").write_text("<html><body>Game</body></html>")
+    (game_path / "main.js").write_text("console.log('game');")
+
+    assets_dir = game_path / "assets"
+    assets_dir.mkdir()
+    (assets_dir / "player.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+
+    return game_path
+
+
+@pytest.fixture
+def gdd_file(tmp_path: Path, sample_gdd_data: dict) -> Path:
+    """Create a temporary GDD JSON file."""
+    gdd_path = tmp_path / "gdd.json"
+    with gdd_path.open("w") as f:
+        json.dump(sample_gdd_data, f)
+    return gdd_path
+
+
+@pytest.fixture
+def screenshots_dir(tmp_path: Path) -> Path:
+    """Create a temporary screenshots directory."""
+    screenshots = tmp_path / "screenshots"
+    screenshots.mkdir()
+    (screenshots / "screenshot-01.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 50)
+    (screenshots / "screenshot-02.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 50)
+    return screenshots
+
+
+# =============================================================================
+# Schema Tests
+# =============================================================================
+
+
+class TestPublishSchemas:
+    """Tests for Pydantic schemas."""
+
+    def test_control_mapping_creation(self) -> None:
+        """Test ControlMapping schema."""
+        control = ControlMapping(input="Space", action="Jump")
+        assert control.input == "Space"
+        assert control.action == "Jump"
+
+    def test_feature_highlight_creation(self) -> None:
+        """Test FeatureHighlight schema."""
+        highlight = FeatureHighlight(name="Time Rewind", description="Undo your mistakes")
+        assert highlight.name == "Time Rewind"
+        assert highlight.description == "Undo your mistakes"
+
+    def test_screenshot_creation(self) -> None:
+        """Test Screenshot schema."""
+        screenshot = Screenshot(
+            filename="screen1.png",
+            url="/path/to/screen1.png",
+            caption="Gameplay screenshot",
+            description="Player navigating a puzzle",
+        )
+        assert screenshot.filename == "screen1.png"
+        assert screenshot.caption == "Gameplay screenshot"
+
+    def test_screenshot_optional_fields(self) -> None:
+        """Test Screenshot with minimal fields."""
+        screenshot = Screenshot(filename="screen.png", caption="Test")
+        assert screenshot.url == ""
+        assert screenshot.description is None
+
+    def test_credit_creation(self) -> None:
+        """Test Credit schema."""
+        credit = Credit(role="Developer", name="Test User", link="https://example.com")
+        assert credit.role == "Developer"
+        assert credit.link == "https://example.com"
+
+    def test_technical_details_defaults(self) -> None:
+        """Test TechnicalDetails default values."""
+        details = TechnicalDetails()
+        assert details.resolution == "800x600"
+        assert "Chrome" in details.browser_support
+        assert details.save_support is False
+        assert details.audio is True
+
+    def test_version_info_defaults(self) -> None:
+        """Test VersionInfo default values."""
+        version = VersionInfo()
+        assert version.current == "1.0.0"
+        assert version.changelog == []
+
+    def test_store_page_content_creation(self, sample_store_page_data: dict) -> None:
+        """Test StorePageContent creation."""
+        page = StorePageContent(**sample_store_page_data)
+        assert page.title == "Time Twist"
+        assert page.tagline == "Bend time, solve puzzles, master the paradox."
+        assert len(page.features) == 4
+        assert len(page.controls) == 3
+
+    def test_release_artifact_creation(self) -> None:
+        """Test ReleaseArtifact schema."""
+        artifact = ReleaseArtifact(
+            name="game.zip",
+            path="/path/to/game.zip",
+            size_bytes=1024,
+        )
+        assert artifact.name == "game.zip"
+        assert artifact.size_bytes == 1024
+        assert artifact.checksum is None
+
+    def test_github_release_creation(self) -> None:
+        """Test GitHubRelease schema."""
+        release = GitHubRelease(
+            tag="v1.0.0",
+            name="Time Twist v1.0.0",
+            body="Initial release",
+        )
+        assert release.tag == "v1.0.0"
+        assert release.prerelease is False
+        assert release.draft is True
+
+    def test_publish_output_creation(self, sample_store_page_data: dict) -> None:
+        """Test PublishOutput schema."""
+        store_page = StorePageContent(**sample_store_page_data)
+        output = PublishOutput(
+            store_page=store_page,
+            store_page_markdown="# Game",
+            artifacts=[],
+            release_type=ReleaseType.INITIAL,
+        )
+        assert output.version == "1.0.0"
+        assert output.classification == ItchioClassification.GAME
+        assert output.visibility == ItchioVisibility.DRAFT
+
+
+class TestPublishEnums:
+    """Tests for enum types."""
+
+    def test_release_type_values(self) -> None:
+        """Test ReleaseType enum values."""
+        assert ReleaseType.INITIAL == "initial"
+        assert ReleaseType.UPDATE == "update"
+        assert ReleaseType.PATCH == "patch"
+        assert ReleaseType.BETA == "beta"
+        assert ReleaseType.DEMO == "demo"
+
+    def test_itchio_classification_values(self) -> None:
+        """Test ItchioClassification enum values."""
+        assert ItchioClassification.GAME == "game"
+        assert ItchioClassification.TOOL == "tool"
+        assert ItchioClassification.OTHER == "other"
+
+    def test_itchio_visibility_values(self) -> None:
+        """Test ItchioVisibility enum values."""
+        assert ItchioVisibility.DRAFT == "draft"
+        assert ItchioVisibility.RESTRICTED == "restricted"
+        assert ItchioVisibility.PUBLIC == "public"
+
+
+class TestPublishConfig:
+    """Tests for PublishConfig dataclass."""
+
+    def test_publish_config_defaults(self) -> None:
+        """Test PublishConfig default values."""
+        config = PublishConfig(project_name="test-game")
+        assert config.project_name == "test-game"
+        assert config.version == "1.0.0"
+        assert config.release_type == ReleaseType.INITIAL
+        assert config.visibility == ItchioVisibility.DRAFT
+        assert config.create_github_release is False
+
+    def test_publish_config_custom_values(self, tmp_path: Path) -> None:
+        """Test PublishConfig with custom values."""
+        config = PublishConfig(
+            project_name="my-game",
+            version="2.0.0",
+            release_type=ReleaseType.UPDATE,
+            visibility=ItchioVisibility.PUBLIC,
+            itchio_username="testuser",
+            github_repo="user/repo",
+            create_github_release=True,
+            screenshots_dir=tmp_path,
+            additional_tags=["puzzle", "indie"],
+        )
+        assert config.version == "2.0.0"
+        assert config.release_type == ReleaseType.UPDATE
+        assert config.additional_tags == ["puzzle", "indie"]
+
+
+# =============================================================================
+# PublishAgent Tests
+# =============================================================================
+
+
+class TestPublishAgentBasic:
+    """Basic tests for PublishAgent."""
+
+    def test_agent_name(self) -> None:
+        """Test agent name property."""
+        agent = PublishAgent()
+        assert agent.name == "PublishAgent"
+
+    def test_agent_initialization(self, tmp_path: Path) -> None:
+        """Test agent initialization with options."""
+        agent = PublishAgent(
+            model="claude-sonnet-4-5-20250929",
+            output_dir=tmp_path,
+        )
+        assert agent.model == "claude-sonnet-4-5-20250929"
+        assert agent.output_dir == tmp_path
+
+    def test_client_property_without_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Test that accessing client without API key raises error."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        agent = PublishAgent()
+        agent._settings = MagicMock()
+        agent._settings.anthropic_api_key = None
+
+        with pytest.raises(AgentError) as exc_info:
+            _ = agent.client
+
+        assert "API key" in str(exc_info.value)
+
+
+class TestPublishAgentGDDLoading:
+    """Tests for GDD loading functionality."""
+
+    @pytest.mark.asyncio
+    async def test_load_gdd_from_data(self, sample_gdd_data: dict) -> None:
+        """Test loading GDD from dictionary."""
+        agent = PublishAgent()
+        gdd = await agent._load_gdd(None, sample_gdd_data)
+        assert gdd.title == "Time Twist"
+        assert gdd.genre == "Puzzle Platformer"
+
+    @pytest.mark.asyncio
+    async def test_load_gdd_from_file(self, gdd_file: Path) -> None:
+        """Test loading GDD from JSON file."""
+        agent = PublishAgent()
+        gdd = await agent._load_gdd(gdd_file, None)
+        assert gdd.title == "Time Twist"
+
+    @pytest.mark.asyncio
+    async def test_load_gdd_no_input(self) -> None:
+        """Test that loading without any input raises error."""
+        agent = PublishAgent()
+        with pytest.raises(AgentError) as exc_info:
+            await agent._load_gdd(None, None)
+        assert "gdd_path or gdd_data must be provided" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_load_gdd_file_not_found(self, tmp_path: Path) -> None:
+        """Test error when GDD file doesn't exist."""
+        agent = PublishAgent()
+        with pytest.raises(AgentError) as exc_info:
+            await agent._load_gdd(tmp_path / "nonexistent.json", None)
+        assert "GDD file not found" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_load_gdd_invalid_json(self, tmp_path: Path) -> None:
+        """Test error when GDD file contains invalid JSON."""
+        bad_file = tmp_path / "bad.json"
+        bad_file.write_text("not valid json")
+
+        agent = PublishAgent()
+        with pytest.raises(AgentError) as exc_info:
+            await agent._load_gdd(bad_file, None)
+        assert "Failed to parse GDD JSON" in str(exc_info.value)
+
+
+class TestPublishAgentScreenshots:
+    """Tests for screenshot handling."""
+
+    def test_add_screenshots(self, screenshots_dir: Path, sample_store_page_data: dict) -> None:
+        """Test adding screenshots to store page."""
+        agent = PublishAgent()
+        store_page = StorePageContent(**sample_store_page_data)
+
+        updated = agent._add_screenshots(store_page, screenshots_dir)
+
+        assert len(updated.screenshots) == 2
+        assert updated.screenshots[0].filename == "screenshot-01.png"
+        assert updated.screenshots[1].filename == "screenshot-02.png"
+
+    def test_add_screenshots_empty_dir(self, tmp_path: Path, sample_store_page_data: dict) -> None:
+        """Test with empty screenshots directory."""
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+
+        agent = PublishAgent()
+        store_page = StorePageContent(**sample_store_page_data)
+
+        updated = agent._add_screenshots(store_page, empty_dir)
+        assert len(updated.screenshots) == 0
+
+    def test_add_screenshots_limit(self, tmp_path: Path, sample_store_page_data: dict) -> None:
+        """Test that screenshots are limited to 10."""
+        many_screenshots = tmp_path / "many"
+        many_screenshots.mkdir()
+        for i in range(15):
+            (many_screenshots / f"screen-{i:02d}.png").write_bytes(
+                b"\x89PNG\r\n\x1a\n" + b"\x00" * 10
+            )
+
+        agent = PublishAgent()
+        store_page = StorePageContent(**sample_store_page_data)
+
+        updated = agent._add_screenshots(store_page, many_screenshots)
+        assert len(updated.screenshots) == 10
+
+
+class TestPublishAgentArtifacts:
+    """Tests for artifact packaging."""
+
+    @pytest.mark.asyncio
+    async def test_package_artifacts(self, game_dir: Path, tmp_path: Path) -> None:
+        """Test packaging game artifacts."""
+        agent = PublishAgent(output_dir=tmp_path)
+        config = PublishConfig(project_name="test-game", version="1.0.0")
+
+        artifacts, zip_path = await agent._package_artifacts(game_dir, config)
+
+        # Check artifacts list
+        assert len(artifacts) >= 3  # index.html, main.js, player.png + zip
+
+        # Check zip was created
+        assert zip_path is not None
+        assert zip_path.exists()
+        assert zip_path.name == "test-game-v1.0.0.zip"
+
+        # Verify zip contents
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            names = zf.namelist()
+            assert "index.html" in names
+            assert "main.js" in names
+
+    @pytest.mark.asyncio
+    async def test_package_artifacts_custom_version(self, game_dir: Path, tmp_path: Path) -> None:
+        """Test artifact packaging with custom version."""
+        agent = PublishAgent(output_dir=tmp_path)
+        config = PublishConfig(project_name="my-game", version="2.5.0")
+
+        _, zip_path = await agent._package_artifacts(game_dir, config)
+
+        assert zip_path is not None
+        assert zip_path.name == "my-game-v2.5.0.zip"
+
+
+class TestPublishAgentGitHubRelease:
+    """Tests for GitHub release preparation."""
+
+    def test_prepare_github_release_initial(self, sample_gdd_data: dict) -> None:
+        """Test preparing initial GitHub release."""
+        from game_workflow.agents.schemas import GameDesignDocument
+
+        agent = PublishAgent()
+        gdd = GameDesignDocument.model_validate(sample_gdd_data)
+        config = PublishConfig(
+            project_name="time-twist",
+            version="1.0.0",
+            release_type=ReleaseType.INITIAL,
+        )
+        store_page = StorePageContent(
+            title="Time Twist",
+            tagline="Bend time!",
+            description="A puzzle game.",
+            features=["Feature 1", "Feature 2"],
+            controls=[ControlMapping(input="Space", action="Jump")],
+        )
+
+        release = agent._prepare_github_release(gdd, config, store_page)
+
+        assert release.tag == "v1.0.0"
+        assert release.name == "Time Twist v1.0.0"
+        assert "initial release" in release.body
+        assert release.draft is True
+        assert release.prerelease is False
+
+    def test_prepare_github_release_beta(self, sample_gdd_data: dict) -> None:
+        """Test preparing beta GitHub release."""
+        from game_workflow.agents.schemas import GameDesignDocument
+
+        agent = PublishAgent()
+        gdd = GameDesignDocument.model_validate(sample_gdd_data)
+        config = PublishConfig(
+            project_name="time-twist",
+            version="0.9.0",
+            release_type=ReleaseType.BETA,
+        )
+        store_page = StorePageContent(
+            title="Time Twist",
+            tagline="Bend time!",
+            description="A puzzle game.",
+            features=["Feature 1"],
+            controls=[ControlMapping(input="Space", action="Jump")],
+        )
+
+        release = agent._prepare_github_release(gdd, config, store_page)
+
+        assert release.tag == "v0.9.0"
+        assert release.prerelease is True
+
+
+class TestPublishAgentStorePageRendering:
+    """Tests for store page rendering."""
+
+    def test_render_store_page(self, sample_store_page_data: dict) -> None:
+        """Test rendering store page to markdown."""
+        agent = PublishAgent()
+        store_page = StorePageContent(**sample_store_page_data)
+
+        markdown = agent._render_store_page(store_page)
+
+        assert "# Time Twist" in markdown
+        assert "Bend time, solve puzzles, master the paradox." in markdown
+        assert "Arrow Keys" in markdown
+        assert "Made with Phaser" in markdown
+
+    def test_render_store_page_with_screenshots(self, sample_store_page_data: dict) -> None:
+        """Test rendering store page with screenshots."""
+        sample_store_page_data["screenshots"] = [
+            {"filename": "screen1.png", "url": "/img/screen1.png", "caption": "Gameplay"},
+        ]
+        agent = PublishAgent()
+        store_page = StorePageContent(**sample_store_page_data)
+
+        markdown = agent._render_store_page(store_page)
+
+        assert "## Screenshots" in markdown
+        assert "Gameplay" in markdown
+
+
+class TestPublishAgentJSONParsing:
+    """Tests for JSON response parsing."""
+
+    def test_parse_json_response_clean(self) -> None:
+        """Test parsing clean JSON response."""
+        agent = PublishAgent()
+        text = '{"title": "Test", "version": "1.0"}'
+
+        result = agent._parse_json_response(text)
+
+        assert result["title"] == "Test"
+        assert result["version"] == "1.0"
+
+    def test_parse_json_response_with_code_block(self) -> None:
+        """Test parsing JSON wrapped in markdown code block."""
+        agent = PublishAgent()
+        text = '```json\n{"title": "Test"}\n```'
+
+        result = agent._parse_json_response(text)
+
+        assert result["title"] == "Test"
+
+    def test_parse_json_response_with_surrounding_text(self) -> None:
+        """Test parsing JSON with surrounding text."""
+        agent = PublishAgent()
+        text = 'Here is the response:\n{"title": "Test"}\nThank you!'
+
+        result = agent._parse_json_response(text)
+
+        assert result["title"] == "Test"
+
+    def test_parse_json_response_invalid(self) -> None:
+        """Test parsing invalid JSON raises error."""
+        agent = PublishAgent()
+        text = "This is not valid JSON at all"
+
+        with pytest.raises(AgentError) as exc_info:
+            agent._parse_json_response(text)
+
+        assert "Failed to parse JSON" in str(exc_info.value)
+
+
+class TestPublishAgentSaveArtifacts:
+    """Tests for artifact saving."""
+
+    @pytest.mark.asyncio
+    async def test_save_artifacts(self, tmp_path: Path, sample_store_page_data: dict) -> None:
+        """Test saving publish artifacts."""
+        agent = PublishAgent(output_dir=tmp_path)
+        store_page = StorePageContent(**sample_store_page_data)
+        output = PublishOutput(
+            store_page=store_page,
+            store_page_markdown="# Test Game\n\nDescription",
+            artifacts=[],
+            release_type=ReleaseType.INITIAL,
+        )
+
+        saved = await agent._save_artifacts(output)
+
+        assert "store_page_md" in saved
+        assert "store_page_json" in saved
+        assert "publish_output" in saved
+
+        # Verify files exist
+        assert (tmp_path / "store-page.md").exists()
+        assert (tmp_path / "store-page.json").exists()
+        assert (tmp_path / "publish-output.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_save_artifacts_with_github_release(
+        self, tmp_path: Path, sample_store_page_data: dict
+    ) -> None:
+        """Test saving artifacts including GitHub release notes."""
+        agent = PublishAgent(output_dir=tmp_path)
+        store_page = StorePageContent(**sample_store_page_data)
+        github_release = GitHubRelease(
+            tag="v1.0.0",
+            name="Test v1.0.0",
+            body="# Release Notes\n\nInitial release!",
+        )
+        output = PublishOutput(
+            store_page=store_page,
+            store_page_markdown="# Test",
+            artifacts=[],
+            release_type=ReleaseType.INITIAL,
+            github_release=github_release,
+        )
+
+        saved = await agent._save_artifacts(output)
+
+        assert "release_notes" in saved
+        assert (tmp_path / "release-notes.md").exists()
+
+    @pytest.mark.asyncio
+    async def test_save_artifacts_no_output_dir(self, sample_store_page_data: dict) -> None:
+        """Test error when output directory not set."""
+        agent = PublishAgent()  # No output_dir
+        store_page = StorePageContent(**sample_store_page_data)
+        output = PublishOutput(
+            store_page=store_page,
+            store_page_markdown="# Test",
+            artifacts=[],
+            release_type=ReleaseType.INITIAL,
+        )
+
+        with pytest.raises(AgentError) as exc_info:
+            await agent._save_artifacts(output)
+
+        assert "Output directory not set" in str(exc_info.value)
+
+
+class TestPublishAgentRun:
+    """Tests for the main run method."""
+
+    @pytest.mark.asyncio
+    async def test_run_game_dir_not_found(self, tmp_path: Path, sample_gdd_data: dict) -> None:
+        """Test error when game directory doesn't exist."""
+        agent = PublishAgent()
+
+        with pytest.raises(AgentError) as exc_info:
+            await agent.run(
+                game_dir=tmp_path / "nonexistent",
+                gdd_data=sample_gdd_data,
+            )
+
+        assert "Game directory not found" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_run_full_workflow(
+        self,
+        game_dir: Path,
+        sample_gdd_data: dict,
+        sample_api_response: Message,
+        tmp_path: Path,
+    ) -> None:
+        """Test full publish workflow with mocked API."""
+        agent = PublishAgent(output_dir=tmp_path / "publish")
+
+        with patch.object(agent, "_client") as mock_client:
+            mock_client.messages.create.return_value = sample_api_response
+
+            result = await agent.run(
+                game_dir=game_dir,
+                gdd_data=sample_gdd_data,
+            )
+
+        assert result["status"] == "success"
+        assert "store_page" in result
+        assert "artifacts" in result
+        assert "zip_path" in result
+
+    @pytest.mark.asyncio
+    async def test_run_with_github_release(
+        self,
+        game_dir: Path,
+        sample_gdd_data: dict,
+        sample_api_response: Message,
+        tmp_path: Path,
+    ) -> None:
+        """Test workflow with GitHub release enabled."""
+        agent = PublishAgent(output_dir=tmp_path / "publish")
+        config = PublishConfig(
+            project_name="test-game",
+            create_github_release=True,
+        )
+
+        with patch.object(agent, "_client") as mock_client:
+            mock_client.messages.create.return_value = sample_api_response
+
+            result = await agent.run(
+                game_dir=game_dir,
+                gdd_data=sample_gdd_data,
+                config=config,
+            )
+
+        assert result["github_release"] is not None
+        assert result["github_release"]["tag"] == "v1.0.0"
+
+
+class TestPublishAgentTextExtraction:
+    """Tests for API response text extraction."""
+
+    def test_extract_text_from_response(self, sample_api_response: Message) -> None:
+        """Test extracting text from API response."""
+        agent = PublishAgent()
+        text = agent._extract_text(sample_api_response)
+        assert "Time Twist" in text
+
+    def test_extract_text_empty_response(self) -> None:
+        """Test extracting text from empty response."""
+        agent = PublishAgent()
+        response = Message(
+            id="msg_test",
+            type="message",
+            role="assistant",
+            content=[],
+            model="claude-sonnet-4-5-20250929",
+            stop_reason="end_turn",
+            stop_sequence=None,
+            usage=Usage(input_tokens=0, output_tokens=0),
+        )
+
+        text = agent._extract_text(response)
+        assert text == ""
+
+
+class TestPublishAgentGDDSummary:
+    """Tests for GDD summary generation."""
+
+    def test_summarize_gdd(self, sample_gdd_data: dict) -> None:
+        """Test GDD summarization for marketing prompt."""
+        from game_workflow.agents.schemas import GameDesignDocument
+
+        agent = PublishAgent()
+        gdd = GameDesignDocument.model_validate(sample_gdd_data)
+
+        summary = agent._summarize_gdd(gdd)
+
+        assert "Time Twist" in summary
+        assert "Puzzle Platformer" in summary
+        assert "Time Rewind" in summary
+        assert "Multiple simultaneous timelines" in summary
+
+
+# =============================================================================
+# Schema Export Tests
+# =============================================================================
+
+
+class TestSchemaExport:
+    """Tests for JSON Schema export functions."""
+
+    def test_get_store_page_schema(self) -> None:
+        """Test StorePageContent schema export."""
+        schema = get_store_page_schema()
+
+        assert "properties" in schema
+        assert "title" in schema["properties"]
+        assert "tagline" in schema["properties"]
+        assert "features" in schema["properties"]
+
+    def test_get_publish_output_schema(self) -> None:
+        """Test PublishOutput schema export."""
+        schema = get_publish_output_schema()
+
+        assert "properties" in schema
+        assert "store_page" in schema["properties"]
+        assert "artifacts" in schema["properties"]
+        assert "release_type" in schema["properties"]


### PR DESCRIPTION
## Summary

- Create itch.io page template with Jinja2 syntax for store pages
- Implement PublishAgent for release preparation (marketing copy, artifacts, GitHub release)
- Add comprehensive Pydantic schemas for publish outputs
- Write 48 unit tests for PublishAgent
- Update templates.py with render_itchio_page helper

## Tasks Completed

- [x] **5.1** Create itch.io page template (`templates/itchio-page.md`)
  - Store page description structure with title, tagline, description
  - Controls, features, screenshots, technical details sections
  - Credits, version history, support information
  - Tag recommendations

- [x] **5.2** Implement PublishAgent (`src/game_workflow/agents/publish.py`)
  - Generate marketing copy from GDD using Claude API
  - Prepare store page content with StorePageContent schema
  - Package build artifacts into zip archives
  - Prepare GitHub release metadata
  - Save all publish artifacts

- [x] **5.3** Write unit tests for PublishAgent (48 tests)
  - Schema validation tests
  - GDD loading tests (file and data)
  - Screenshot handling tests
  - Artifact packaging tests
  - GitHub release preparation tests
  - Store page rendering tests

## Test plan

- [x] All 206 unit tests pass
- [x] Ruff linting passes
- [x] Ruff format check passes
- [x] Mypy type checking passes
- [x] CI workflow should pass

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)