### PR TITLE
feat(mcp): Implement Phase 6 MCP Servers

### DIFF
--- a/src/game_workflow/hooks/__init__.py
+++ b/src/game_workflow/hooks/__init__.py
@@ -11,12 +11,22 @@ multiple behaviors to the workflow orchestrator.
 
 from game_workflow.hooks.checkpoint import CheckpointHook
 from game_workflow.hooks.logging import JSONFormatter, LoggingHook, setup_logging
-from game_workflow.hooks.slack_approval import SlackApprovalHook
+from game_workflow.hooks.slack_approval import (
+    ApprovalRequest,
+    ApprovalStatus,
+    SlackApprovalHook,
+    SlackClient,
+    SlackMessage,
+)
 
 __all__ = [
+    "ApprovalRequest",
+    "ApprovalStatus",
     "CheckpointHook",
     "JSONFormatter",
     "LoggingHook",
     "SlackApprovalHook",
+    "SlackClient",
+    "SlackMessage",
     "setup_logging",
 ]

--- a/src/game_workflow/hooks/slack_approval.py
+++ b/src/game_workflow/hooks/slack_approval.py
@@ -4,23 +4,472 @@ This hook sends approval requests to Slack and waits for
 human confirmation before proceeding.
 """
 
-from typing import Any
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, ClassVar
+
+import httpx
+
+from game_workflow.orchestrator.exceptions import (
+    ApprovalRejectedError,
+    ApprovalTimeoutError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ApprovalStatus(str, Enum):
+    """Status of an approval request."""
+
+    PENDING = "pending"
+    APPROVED = "approved"
+    REJECTED = "rejected"
+    EXPIRED = "expired"
+
+
+@dataclass
+class ApprovalRequest:
+    """Represents an approval request."""
+
+    id: str
+    channel: str
+    message: str
+    context: dict[str, Any] | None = None
+    status: ApprovalStatus = ApprovalStatus.PENDING
+    created_at: float = field(default_factory=time.time)
+    responded_at: float | None = None
+    responder: str | None = None
+    feedback: str | None = None
+    thread_ts: str | None = None
+    message_ts: str | None = None
+
+
+@dataclass
+class SlackMessage:
+    """Represents a Slack message."""
+
+    channel: str
+    ts: str
+    text: str | None = None
+    user: str | None = None
+    thread_ts: str | None = None
+    reactions: list[dict[str, Any]] = field(default_factory=list)
+
+
+class SlackClient:
+    """Async client for Slack API.
+
+    Uses Slack Web API for sending messages and checking reactions.
+    """
+
+    BASE_URL = "https://slack.com/api"
+
+    def __init__(
+        self,
+        token: str | None = None,
+        *,
+        timeout: float = 30.0,
+    ) -> None:
+        """Initialize the Slack client.
+
+        Args:
+            token: Slack bot token. If None, uses SLACK_BOT_TOKEN env var.
+            timeout: Request timeout in seconds.
+        """
+        self.token = token or os.environ.get("SLACK_BOT_TOKEN", "")
+        self.timeout = timeout
+        self._client: httpx.AsyncClient | None = None
+
+    async def __aenter__(self) -> SlackClient:
+        """Enter async context."""
+        self._client = httpx.AsyncClient(
+            base_url=self.BASE_URL,
+            headers={"Authorization": f"Bearer {self.token}"},
+            timeout=self.timeout,
+        )
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
+        """Exit async context."""
+        await self.close()
+
+    @property
+    def client(self) -> httpx.AsyncClient:
+        """Get the HTTP client, creating if necessary."""
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                base_url=self.BASE_URL,
+                headers={"Authorization": f"Bearer {self.token}"},
+                timeout=self.timeout,
+            )
+        return self._client
+
+    async def close(self) -> None:
+        """Close the HTTP client."""
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Make a Slack API request.
+
+        Args:
+            method: HTTP method.
+            endpoint: API endpoint.
+            **kwargs: Additional arguments for httpx.
+
+        Returns:
+            API response data.
+
+        Raises:
+            RuntimeError: If the request fails.
+        """
+        try:
+            response = await self.client.request(method, endpoint, **kwargs)
+            data = response.json()
+
+            if not data.get("ok"):
+                error = data.get("error", "Unknown error")
+                raise RuntimeError(f"Slack API error: {error}")
+
+            return data
+
+        except httpx.HTTPError as e:
+            raise RuntimeError(f"Slack request failed: {e}") from e
+
+    async def post_message(
+        self,
+        channel: str,
+        text: str,
+        *,
+        blocks: list[dict[str, Any]] | None = None,
+        thread_ts: str | None = None,
+        unfurl_links: bool = False,
+    ) -> dict[str, Any]:
+        """Post a message to a Slack channel.
+
+        Args:
+            channel: Channel ID or name.
+            text: Message text (fallback for notifications).
+            blocks: Block Kit blocks for rich formatting.
+            thread_ts: Thread timestamp for replies.
+            unfurl_links: Whether to unfurl links.
+
+        Returns:
+            API response with message details.
+        """
+        payload: dict[str, Any] = {
+            "channel": channel,
+            "text": text,
+            "unfurl_links": unfurl_links,
+        }
+
+        if blocks:
+            payload["blocks"] = blocks
+
+        if thread_ts:
+            payload["thread_ts"] = thread_ts
+
+        return await self._request("POST", "/chat.postMessage", json=payload)
+
+    async def update_message(
+        self,
+        channel: str,
+        ts: str,
+        text: str,
+        *,
+        blocks: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Update an existing message.
+
+        Args:
+            channel: Channel ID.
+            ts: Message timestamp.
+            text: New message text.
+            blocks: New Block Kit blocks.
+
+        Returns:
+            API response.
+        """
+        payload: dict[str, Any] = {
+            "channel": channel,
+            "ts": ts,
+            "text": text,
+        }
+
+        if blocks:
+            payload["blocks"] = blocks
+
+        return await self._request("POST", "/chat.update", json=payload)
+
+    async def get_reactions(
+        self,
+        channel: str,
+        ts: str,
+    ) -> list[dict[str, Any]]:
+        """Get reactions on a message.
+
+        Args:
+            channel: Channel ID.
+            ts: Message timestamp.
+
+        Returns:
+            List of reactions.
+        """
+        try:
+            data = await self._request(
+                "GET",
+                "/reactions.get",
+                params={"channel": channel, "timestamp": ts},
+            )
+            message = data.get("message", {})
+            return message.get("reactions", [])
+        except RuntimeError:
+            return []
+
+    async def get_replies(
+        self,
+        channel: str,
+        ts: str,
+        *,
+        limit: int = 100,
+    ) -> list[dict[str, Any]]:
+        """Get replies in a thread.
+
+        Args:
+            channel: Channel ID.
+            ts: Thread parent timestamp.
+            limit: Maximum number of replies.
+
+        Returns:
+            List of reply messages.
+        """
+        try:
+            data = await self._request(
+                "GET",
+                "/conversations.replies",
+                params={"channel": channel, "ts": ts, "limit": limit},
+            )
+            messages = data.get("messages", [])
+            # First message is the parent, rest are replies
+            return messages[1:] if len(messages) > 1 else []
+        except RuntimeError:
+            return []
+
+    async def test_auth(self) -> dict[str, Any] | None:
+        """Test authentication and get bot info.
+
+        Returns:
+            Bot info if authenticated, None otherwise.
+        """
+        try:
+            return await self._request("POST", "/auth.test")
+        except RuntimeError:
+            return None
 
 
 class SlackApprovalHook:
     """Hook for requesting human approval via Slack.
 
     Sends interactive messages to Slack and waits for
-    approval/rejection responses.
+    approval/rejection responses via reactions or replies.
+
+    Example:
+        hook = SlackApprovalHook(channel="#game-dev")
+        approved = await hook.request_approval(
+            message="Ready to publish game?",
+            context={"game": "My Game", "version": "1.0.0"},
+        )
+        if approved:
+            print("Proceeding with publish")
     """
 
-    def __init__(self, channel: str = "#game-dev") -> None:
+    # Default reaction emojis for approval/rejection
+    APPROVE_REACTIONS: ClassVar[set[str]] = {"white_check_mark", "heavy_check_mark", "+1", "thumbsup"}
+    REJECT_REACTIONS: ClassVar[set[str]] = {"x", "no_entry", "-1", "thumbsdown"}
+
+    def __init__(
+        self,
+        channel: str = "#game-dev",
+        *,
+        token: str | None = None,
+        poll_interval: float = 5.0,
+        require_thread_reply: bool = False,
+    ) -> None:
         """Initialize the hook.
 
         Args:
             channel: Slack channel for approval requests.
+            token: Slack bot token. If None, uses SLACK_BOT_TOKEN env var.
+            poll_interval: Interval between checks in seconds.
+            require_thread_reply: If True, require reply instead of reaction.
         """
         self.channel = channel
+        self.token = token
+        self.poll_interval = poll_interval
+        self.require_thread_reply = require_thread_reply
+        self._pending_requests: dict[str, ApprovalRequest] = {}
+
+    def _create_approval_blocks(
+        self,
+        message: str,
+        context: dict[str, Any] | None = None,
+        request_id: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Create Block Kit blocks for approval message.
+
+        Args:
+            message: Main approval message.
+            context: Additional context to display.
+            request_id: Unique request ID.
+
+        Returns:
+            List of Block Kit blocks.
+        """
+        blocks: list[dict[str, Any]] = [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": "Approval Required",
+                    "emoji": True,
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": message,
+                },
+            },
+        ]
+
+        # Add context if provided
+        if context:
+            context_text = "\n".join(
+                f"*{k}:* {v}" for k, v in context.items()
+            )
+            blocks.append({
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": context_text,
+                },
+            })
+
+        blocks.append({"type": "divider"})
+
+        # Add instructions
+        if self.require_thread_reply:
+            instruction = (
+                "Reply to this thread with `approve` or `reject` to respond.\n"
+                "You can include feedback in your reply."
+            )
+        else:
+            instruction = (
+                "React with :white_check_mark: to approve or :x: to reject.\n"
+                "Alternatively, reply in thread with `approve` or `reject`."
+            )
+
+        blocks.append({
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": instruction,
+                },
+            ],
+        })
+
+        if request_id:
+            blocks.append({
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"_Request ID: {request_id}_",
+                    },
+                ],
+            })
+
+        return blocks
+
+    def _create_response_blocks(
+        self,
+        original_message: str,
+        status: ApprovalStatus,
+        responder: str | None = None,
+        feedback: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Create Block Kit blocks for response update.
+
+        Args:
+            original_message: Original approval message.
+            status: Final status.
+            responder: Who responded.
+            feedback: Any feedback provided.
+
+        Returns:
+            List of Block Kit blocks.
+        """
+        status_emoji = ":white_check_mark:" if status == ApprovalStatus.APPROVED else ":x:"
+        status_text = "Approved" if status == ApprovalStatus.APPROVED else "Rejected"
+
+        blocks: list[dict[str, Any]] = [
+            {
+                "type": "header",
+                "text": {
+                    "type": "plain_text",
+                    "text": f"{status_emoji} {status_text}",
+                    "emoji": True,
+                },
+            },
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"~{original_message}~",
+                },
+            },
+        ]
+
+        if responder:
+            blocks.append({
+                "type": "context",
+                "elements": [
+                    {
+                        "type": "mrkdwn",
+                        "text": f"Responded by <@{responder}>",
+                    },
+                ],
+            })
+
+        if feedback:
+            blocks.append({
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*Feedback:* {feedback}",
+                },
+            })
+
+        return blocks
 
     async def request_approval(
         self,
@@ -40,6 +489,223 @@ class SlackApprovalHook:
 
         Raises:
             ApprovalTimeoutError: If timeout is reached.
+            ApprovalRejectedError: If explicitly rejected with feedback.
         """
-        # TODO: Implement Slack approval flow
-        raise NotImplementedError("Slack approval not yet implemented")
+        import uuid
+
+        request_id = str(uuid.uuid4())[:8]
+        timeout_seconds = timeout_minutes * 60 if timeout_minutes else None
+
+        logger.info(
+            "Requesting approval in %s (timeout: %s minutes)",
+            self.channel,
+            timeout_minutes,
+        )
+
+        async with SlackClient(token=self.token) as client:
+            # Check authentication
+            auth = await client.test_auth()
+            if not auth:
+                raise RuntimeError("Failed to authenticate with Slack")
+
+            # Create and send approval message
+            blocks = self._create_approval_blocks(message, context, request_id)
+            fallback_text = f"Approval Required: {message}"
+
+            response = await client.post_message(
+                channel=self.channel,
+                text=fallback_text,
+                blocks=blocks,
+            )
+
+            channel_id = response.get("channel", self.channel)
+            message_ts = response.get("ts", "")
+
+            # Create request record
+            request = ApprovalRequest(
+                id=request_id,
+                channel=channel_id,
+                message=message,
+                context=context,
+                message_ts=message_ts,
+                thread_ts=message_ts,
+            )
+            self._pending_requests[request_id] = request
+
+            try:
+                # Poll for response
+                start_time = time.time()
+
+                while True:
+                    # Check timeout
+                    if timeout_seconds:
+                        elapsed = time.time() - start_time
+                        if elapsed >= timeout_seconds:
+                            request.status = ApprovalStatus.EXPIRED
+                            raise ApprovalTimeoutError(
+                                f"Approval request timed out after {timeout_minutes} minutes"
+                            )
+
+                    # Check reactions
+                    if not self.require_thread_reply:
+                        reactions = await client.get_reactions(channel_id, message_ts)
+                        status, responder = self._check_reactions(reactions)
+                        if status:
+                            request.status = status
+                            request.responder = responder
+                            request.responded_at = time.time()
+                            break
+
+                    # Check thread replies
+                    replies = await client.get_replies(channel_id, message_ts)
+                    status, responder, feedback = self._check_replies(replies)
+                    if status:
+                        request.status = status
+                        request.responder = responder
+                        request.feedback = feedback
+                        request.responded_at = time.time()
+                        break
+
+                    await asyncio.sleep(self.poll_interval)
+
+                # Update the original message
+                response_blocks = self._create_response_blocks(
+                    message, request.status, request.responder, request.feedback
+                )
+                await client.update_message(
+                    channel=channel_id,
+                    ts=message_ts,
+                    text=f"{request.status.value}: {message}",
+                    blocks=response_blocks,
+                )
+
+                if request.status == ApprovalStatus.APPROVED:
+                    logger.info("Approval granted by %s", request.responder)
+                    return True
+                else:
+                    logger.info("Approval rejected by %s", request.responder)
+                    if request.feedback:
+                        raise ApprovalRejectedError(
+                            f"Rejected by {request.responder}: {request.feedback}"
+                        )
+                    return False
+
+            finally:
+                # Clean up
+                self._pending_requests.pop(request_id, None)
+
+    def _check_reactions(
+        self,
+        reactions: list[dict[str, Any]],
+    ) -> tuple[ApprovalStatus | None, str | None]:
+        """Check reactions for approval/rejection.
+
+        Args:
+            reactions: List of reaction objects.
+
+        Returns:
+            Tuple of (status, responder_user_id).
+        """
+        for reaction in reactions:
+            name = reaction.get("name", "")
+            users = reaction.get("users", [])
+
+            if not users:
+                continue
+
+            if name in self.APPROVE_REACTIONS:
+                return ApprovalStatus.APPROVED, users[0]
+            elif name in self.REJECT_REACTIONS:
+                return ApprovalStatus.REJECTED, users[0]
+
+        return None, None
+
+    def _check_replies(
+        self,
+        replies: list[dict[str, Any]],
+    ) -> tuple[ApprovalStatus | None, str | None, str | None]:
+        """Check thread replies for approval/rejection.
+
+        Args:
+            replies: List of reply message objects.
+
+        Returns:
+            Tuple of (status, responder_user_id, feedback).
+        """
+        for reply in replies:
+            text = reply.get("text", "").lower().strip()
+            user = reply.get("user")
+
+            if not text or not user:
+                continue
+
+            # Check for approval
+            if text.startswith("approve"):
+                feedback = text[7:].strip() if len(text) > 7 else None
+                return ApprovalStatus.APPROVED, user, feedback
+
+            # Check for rejection
+            if text.startswith("reject"):
+                feedback = text[6:].strip() if len(text) > 6 else None
+                return ApprovalStatus.REJECTED, user, feedback
+
+            # Check for simple yes/no
+            if text in ("yes", "ok", "lgtm", "go", "ship it"):
+                return ApprovalStatus.APPROVED, user, None
+            if text in ("no", "stop", "wait", "hold"):
+                return ApprovalStatus.REJECTED, user, None
+
+        return None, None, None
+
+    async def send_notification(
+        self,
+        message: str,
+        *,
+        context: dict[str, Any] | None = None,
+        level: str = "info",
+    ) -> bool:
+        """Send a notification to Slack (no approval required).
+
+        Args:
+            message: Notification message.
+            context: Additional context.
+            level: Notification level (info, warning, error, success).
+
+        Returns:
+            True if sent successfully.
+        """
+        level_emoji = {
+            "info": ":information_source:",
+            "warning": ":warning:",
+            "error": ":x:",
+            "success": ":white_check_mark:",
+        }.get(level, ":speech_balloon:")
+
+        blocks: list[dict[str, Any]] = [
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"{level_emoji} {message}",
+                },
+            },
+        ]
+
+        if context:
+            context_text = "\n".join(f"*{k}:* {v}" for k, v in context.items())
+            blocks.append({
+                "type": "context",
+                "elements": [{"type": "mrkdwn", "text": context_text}],
+            })
+
+        try:
+            async with SlackClient(token=self.token) as client:
+                await client.post_message(
+                    channel=self.channel,
+                    text=f"{level.upper()}: {message}",
+                    blocks=blocks,
+                )
+            return True
+        except Exception as e:
+            logger.error("Failed to send Slack notification: %s", e)
+            return False

--- a/src/game_workflow/mcp_servers/__init__.py
+++ b/src/game_workflow/mcp_servers/__init__.py
@@ -1,9 +1,17 @@
 """MCP server implementations and registry.
 
 This module contains custom MCP servers and the registry
-for managing server configurations.
+for managing server configurations and lifecycle.
 """
 
-from game_workflow.mcp_servers.registry import MCPServerRegistry
+from game_workflow.mcp_servers.registry import (
+    MCPServerConfig,
+    MCPServerProcess,
+    MCPServerRegistry,
+)
 
-__all__ = ["MCPServerRegistry"]
+__all__ = [
+    "MCPServerConfig",
+    "MCPServerProcess",
+    "MCPServerRegistry",
+]

--- a/src/game_workflow/mcp_servers/itchio/__init__.py
+++ b/src/game_workflow/mcp_servers/itchio/__init__.py
@@ -4,7 +4,36 @@ This module provides an MCP server for interacting with itch.io,
 including game uploads via butler and API interactions.
 """
 
-from game_workflow.mcp_servers.itchio.api import ItchioAPI
-from game_workflow.mcp_servers.itchio.butler import ButlerCLI
+from game_workflow.mcp_servers.itchio.api import (
+    APIResponse,
+    GameClassification,
+    GameType,
+    ItchioAPI,
+    ItchioAPIError,
+    ItchioGame,
+    ItchioUpload,
+    ItchioUser,
+    ReleaseStatus,
+)
+from game_workflow.mcp_servers.itchio.butler import (
+    ButlerCLI,
+    ButlerPushResult,
+    ButlerStatusResult,
+    ButlerVersion,
+)
 
-__all__ = ["ButlerCLI", "ItchioAPI"]
+__all__ = [
+    "APIResponse",
+    "ButlerCLI",
+    "ButlerPushResult",
+    "ButlerStatusResult",
+    "ButlerVersion",
+    "GameClassification",
+    "GameType",
+    "ItchioAPI",
+    "ItchioAPIError",
+    "ItchioGame",
+    "ItchioUpload",
+    "ItchioUser",
+    "ReleaseStatus",
+]

--- a/src/game_workflow/mcp_servers/itchio/api.py
+++ b/src/game_workflow/mcp_servers/itchio/api.py
@@ -1,11 +1,272 @@
 """itch.io API client.
 
-This module provides a client for the itch.io API.
+This module provides an async client for the itch.io API.
 """
 
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any
 
 import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class GameType(str, Enum):
+    """Type of game on itch.io."""
+
+    DEFAULT = "default"
+    FLASH = "flash"
+    UNITY = "unity"
+    JAVA = "java"
+    HTML = "html"
+
+
+class GameClassification(str, Enum):
+    """Classification of game on itch.io."""
+
+    GAME = "game"
+    TOOL = "tool"
+    ASSETS = "assets"
+    GAME_MOD = "game_mod"
+    PHYSICAL_GAME = "physical_game"
+    SOUNDTRACK = "soundtrack"
+    OTHER = "other"
+    COMIC = "comic"
+    BOOK = "book"
+
+
+class ReleaseStatus(str, Enum):
+    """Release status of a game."""
+
+    RELEASED = "released"
+    IN_DEVELOPMENT = "in-development"
+    PROTOTYPE = "prototype"
+    ON_HOLD = "on-hold"
+    CANCELLED = "cancelled"
+
+
+@dataclass
+class ItchioGame:
+    """Representation of an itch.io game."""
+
+    id: int
+    url: str
+    title: str
+    short_text: str | None = None
+    type: GameType = GameType.DEFAULT
+    classification: GameClassification = GameClassification.GAME
+    created_at: str | None = None
+    published_at: str | None = None
+    cover_url: str | None = None
+    min_price: int = 0  # In cents
+    can_be_bought: bool = False
+    has_demo: bool = False
+    in_press_system: bool = False
+    p_windows: bool = False
+    p_linux: bool = False
+    p_osx: bool = False
+    p_android: bool = False
+    downloads_count: int = 0
+    views_count: int = 0
+    purchases_count: int = 0
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ItchioGame:
+        """Create a game from API response data.
+
+        Args:
+            data: Dictionary from API response.
+
+        Returns:
+            ItchioGame instance.
+        """
+        game_type = data.get("type", "default")
+        if game_type and isinstance(game_type, str):
+            try:
+                game_type = GameType(game_type)
+            except ValueError:
+                game_type = GameType.DEFAULT
+        else:
+            game_type = GameType.DEFAULT
+
+        classification = data.get("classification", "game")
+        if classification and isinstance(classification, str):
+            try:
+                classification = GameClassification(classification)
+            except ValueError:
+                classification = GameClassification.GAME
+        else:
+            classification = GameClassification.GAME
+
+        return cls(
+            id=data.get("id", 0),
+            url=data.get("url", ""),
+            title=data.get("title", ""),
+            short_text=data.get("short_text"),
+            type=game_type,
+            classification=classification,
+            created_at=data.get("created_at"),
+            published_at=data.get("published_at"),
+            cover_url=data.get("cover_url"),
+            min_price=data.get("min_price", 0),
+            can_be_bought=data.get("can_be_bought", False),
+            has_demo=data.get("has_demo", False),
+            in_press_system=data.get("in_press_system", False),
+            p_windows=data.get("p_windows", False),
+            p_linux=data.get("p_linux", False),
+            p_osx=data.get("p_osx", False),
+            p_android=data.get("p_android", False),
+            downloads_count=data.get("downloads_count", 0),
+            views_count=data.get("views_count", 0),
+            purchases_count=data.get("purchases_count", 0),
+        )
+
+
+@dataclass
+class ItchioUpload:
+    """Representation of an itch.io upload (game file)."""
+
+    id: int
+    game_id: int
+    filename: str
+    display_name: str | None = None
+    size: int = 0
+    channel_name: str | None = None
+    build_id: int | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    storage: str | None = None
+    md5_hash: str | None = None
+    p_windows: bool = False
+    p_linux: bool = False
+    p_osx: bool = False
+    p_android: bool = False
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ItchioUpload:
+        """Create an upload from API response data.
+
+        Args:
+            data: Dictionary from API response.
+
+        Returns:
+            ItchioUpload instance.
+        """
+        return cls(
+            id=data.get("id", 0),
+            game_id=data.get("game_id", 0),
+            filename=data.get("filename", ""),
+            display_name=data.get("display_name"),
+            size=data.get("size", 0),
+            channel_name=data.get("channel_name"),
+            build_id=data.get("build_id"),
+            created_at=data.get("created_at"),
+            updated_at=data.get("updated_at"),
+            storage=data.get("storage"),
+            md5_hash=data.get("md5_hash"),
+            p_windows=data.get("p_windows", False),
+            p_linux=data.get("p_linux", False),
+            p_osx=data.get("p_osx", False),
+            p_android=data.get("p_android", False),
+        )
+
+
+@dataclass
+class ItchioUser:
+    """Representation of an itch.io user."""
+
+    id: int
+    username: str
+    url: str
+    display_name: str | None = None
+    cover_url: str | None = None
+    gamer: bool = False
+    developer: bool = False
+    press_user: bool = False
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ItchioUser:
+        """Create a user from API response data.
+
+        Args:
+            data: Dictionary from API response.
+
+        Returns:
+            ItchioUser instance.
+        """
+        return cls(
+            id=data.get("id", 0),
+            username=data.get("username", ""),
+            url=data.get("url", ""),
+            display_name=data.get("display_name"),
+            cover_url=data.get("cover_url"),
+            gamer=data.get("gamer", False),
+            developer=data.get("developer", False),
+            press_user=data.get("press_user", False),
+        )
+
+
+@dataclass
+class APIResponse:
+    """Generic API response wrapper."""
+
+    success: bool
+    data: dict[str, Any] | None = None
+    error: str | None = None
+    errors: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_response(cls, response: httpx.Response) -> APIResponse:
+        """Create from httpx response.
+
+        Args:
+            response: The HTTP response.
+
+        Returns:
+            APIResponse instance.
+        """
+        try:
+            data = response.json()
+            errors = data.get("errors", [])
+            if isinstance(errors, str):
+                errors = [errors]
+            return cls(
+                success=response.is_success and not errors,
+                data=data,
+                error=errors[0] if errors else None,
+                errors=errors,
+            )
+        except Exception as e:
+            return cls(
+                success=False,
+                error=f"Failed to parse response: {e}",
+            )
+
+
+class ItchioAPIError(Exception):
+    """Exception raised for itch.io API errors."""
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int | None = None,
+        errors: list[str] | None = None,
+    ) -> None:
+        """Initialize the error.
+
+        Args:
+            message: Error message.
+            status_code: HTTP status code if applicable.
+            errors: List of error messages from API.
+        """
+        super().__init__(message)
+        self.status_code = status_code
+        self.errors = errors or []
 
 
 class ItchioAPI:
@@ -13,43 +274,284 @@ class ItchioAPI:
 
     Provides methods for interacting with itch.io's REST API
     for game management operations.
+
+    Example:
+        async with ItchioAPI(api_key="...") as api:
+            games = await api.get_my_games()
+            for game in games:
+                print(game.title)
     """
 
     BASE_URL = "https://itch.io/api/1"
 
-    def __init__(self, api_key: str) -> None:
+    def __init__(
+        self,
+        api_key: str | None = None,
+        *,
+        timeout: float = 30.0,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+    ) -> None:
         """Initialize the API client.
 
         Args:
-            api_key: The itch.io API key.
+            api_key: The itch.io API key. If None, uses ITCHIO_API_KEY env var.
+            timeout: Request timeout in seconds.
+            max_retries: Maximum number of retries for failed requests.
+            retry_delay: Delay between retries in seconds.
         """
-        self.api_key = api_key
+        self.api_key = api_key or os.environ.get("ITCHIO_API_KEY", "")
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+        self._client: httpx.AsyncClient | None = None
+
+    async def __aenter__(self) -> ItchioAPI:
+        """Enter async context."""
         self._client = httpx.AsyncClient(
             base_url=self.BASE_URL,
-            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=self.timeout,
+        )
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
+        """Exit async context."""
+        await self.close()
+
+    @property
+    def client(self) -> httpx.AsyncClient:
+        """Get the HTTP client, creating if necessary."""
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                base_url=self.BASE_URL,
+                timeout=self.timeout,
+            )
+        return self._client
+
+    async def close(self) -> None:
+        """Close the HTTP client."""
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    def _get_key_param(self) -> dict[str, str]:
+        """Get the API key parameter for requests."""
+        return {"api_key": self.api_key} if self.api_key else {}
+
+    async def _request(
+        self,
+        method: str,
+        endpoint: str,
+        **kwargs: Any,
+    ) -> APIResponse:
+        """Make an API request with retry logic.
+
+        Args:
+            method: HTTP method.
+            endpoint: API endpoint (without base URL).
+            **kwargs: Additional arguments for httpx.
+
+        Returns:
+            API response.
+        """
+        import asyncio
+
+        # Add API key to params
+        params = kwargs.pop("params", {})
+        params.update(self._get_key_param())
+
+        last_error: Exception | None = None
+
+        for attempt in range(self.max_retries):
+            try:
+                response = await self.client.request(
+                    method,
+                    endpoint,
+                    params=params,
+                    **kwargs,
+                )
+
+                api_response = APIResponse.from_response(response)
+
+                # Check for rate limiting
+                if response.status_code == 429:
+                    if attempt < self.max_retries - 1:
+                        retry_after = int(response.headers.get("Retry-After", self.retry_delay * (attempt + 1)))
+                        logger.warning("Rate limited, retrying in %d seconds", retry_after)
+                        await asyncio.sleep(retry_after)
+                        continue
+                    else:
+                        return APIResponse(
+                            success=False,
+                            error="Rate limit exceeded",
+                        )
+
+                # Check for server errors (5xx)
+                if response.status_code >= 500:
+                    if attempt < self.max_retries - 1:
+                        delay = self.retry_delay * (attempt + 1)
+                        logger.warning("Server error %d, retrying in %f seconds", response.status_code, delay)
+                        await asyncio.sleep(delay)
+                        continue
+                    else:
+                        return APIResponse(
+                            success=False,
+                            error=f"Server error: {response.status_code}",
+                        )
+
+                return api_response
+
+            except httpx.TimeoutException as e:
+                last_error = e
+                if attempt < self.max_retries - 1:
+                    delay = self.retry_delay * (attempt + 1)
+                    logger.warning("Request timeout, retrying in %f seconds", delay)
+                    await asyncio.sleep(delay)
+                else:
+                    return APIResponse(
+                        success=False,
+                        error="Request timeout",
+                    )
+
+            except httpx.RequestError as e:
+                last_error = e
+                if attempt < self.max_retries - 1:
+                    delay = self.retry_delay * (attempt + 1)
+                    logger.warning("Request error: %s, retrying in %f seconds", e, delay)
+                    await asyncio.sleep(delay)
+                else:
+                    return APIResponse(
+                        success=False,
+                        error=f"Request error: {e}",
+                    )
+
+        return APIResponse(
+            success=False,
+            error=str(last_error) if last_error else "Unknown error",
         )
 
-    async def get_my_games(self) -> list[dict[str, Any]]:
+    async def get_me(self) -> ItchioUser | None:
+        """Get the authenticated user's profile.
+
+        Returns:
+            The current user, or None if not authenticated.
+        """
+        response = await self._request("GET", "/me")
+        if not response.success or not response.data:
+            logger.error("Failed to get user profile: %s", response.error)
+            return None
+
+        user_data = response.data.get("user")
+        if not user_data:
+            return None
+
+        return ItchioUser.from_dict(user_data)
+
+    async def get_my_games(self) -> list[ItchioGame]:
         """Get list of games owned by the authenticated user.
 
         Returns:
             List of game objects.
         """
-        # TODO: Implement API call
-        raise NotImplementedError("itch.io API not yet implemented")
+        response = await self._request("GET", "/my-games")
+        if not response.success or not response.data:
+            logger.error("Failed to get games: %s", response.error)
+            return []
 
-    async def get_game(self, game_id: int) -> dict[str, Any]:
+        games_data = response.data.get("games", [])
+        return [ItchioGame.from_dict(g) for g in games_data]
+
+    async def get_game(self, game_id: int) -> ItchioGame | None:
         """Get details for a specific game.
 
         Args:
             game_id: The game ID.
 
         Returns:
-            Game object.
+            Game object, or None if not found.
         """
-        # TODO: Implement API call
-        raise NotImplementedError("itch.io API not yet implemented")
+        response = await self._request("GET", f"/game/{game_id}")
+        if not response.success or not response.data:
+            logger.error("Failed to get game %d: %s", game_id, response.error)
+            return None
 
-    async def close(self) -> None:
-        """Close the HTTP client."""
-        await self._client.aclose()
+        game_data = response.data.get("game")
+        if not game_data:
+            return None
+
+        return ItchioGame.from_dict(game_data)
+
+    async def get_game_uploads(self, game_id: int) -> list[ItchioUpload]:
+        """Get uploads for a specific game.
+
+        Args:
+            game_id: The game ID.
+
+        Returns:
+            List of upload objects.
+        """
+        response = await self._request("GET", f"/game/{game_id}/uploads")
+        if not response.success or not response.data:
+            logger.error("Failed to get uploads for game %d: %s", game_id, response.error)
+            return []
+
+        uploads_data = response.data.get("uploads", [])
+        return [ItchioUpload.from_dict(u) for u in uploads_data]
+
+    async def find_game_by_url(self, game_url: str) -> ItchioGame | None:
+        """Find a game by its URL.
+
+        Args:
+            game_url: The full itch.io game URL.
+
+        Returns:
+            Game object, or None if not found.
+        """
+        # First get all games
+        games = await self.get_my_games()
+        for game in games:
+            if game.url == game_url or game.url in game_url:
+                return game
+        return None
+
+    async def find_game_by_slug(self, username: str, game_slug: str) -> ItchioGame | None:
+        """Find a game by username and slug.
+
+        Args:
+            username: The itch.io username.
+            game_slug: The game slug (URL name).
+
+        Returns:
+            Game object, or None if not found.
+        """
+        expected_url_part = f"{username}.itch.io/{game_slug}"
+        games = await self.get_my_games()
+        for game in games:
+            if expected_url_part in game.url:
+                return game
+        return None
+
+    async def get_credentials(self) -> dict[str, Any] | None:
+        """Get credentials/scopes for the current API key.
+
+        Returns:
+            Credentials information, or None if failed.
+        """
+        response = await self._request("GET", "/credentials/info")
+        if not response.success or not response.data:
+            return None
+        return response.data
+
+    async def check_api_key(self) -> bool:
+        """Check if the API key is valid.
+
+        Returns:
+            True if the API key is valid.
+        """
+        user = await self.get_me()
+        return user is not None

--- a/src/game_workflow/mcp_servers/itchio/butler.py
+++ b/src/game_workflow/mcp_servers/itchio/butler.py
@@ -4,8 +4,97 @@ This module provides a Python wrapper around the butler CLI
 for uploading games to itch.io.
 """
 
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import platform
+import re
+import shutil
+import stat
 import subprocess
+from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING, ClassVar
+
+import httpx
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ButlerVersion:
+    """Butler version information."""
+
+    version: str
+    built_at: str | None = None
+    commit: str | None = None
+
+    @classmethod
+    def from_output(cls, output: str) -> ButlerVersion:
+        """Parse version from butler output.
+
+        Args:
+            output: Output from `butler version` command.
+
+        Returns:
+            Parsed version information.
+        """
+        version = "unknown"
+        built_at = None
+        commit = None
+
+        for line in output.strip().split("\n"):
+            line = line.strip()
+            if "version" in line.lower():
+                # Format: "butler version 15.21.0, built on ..."
+                match = re.search(r"version\s+([\d.]+)", line, re.IGNORECASE)
+                if match:
+                    version = match.group(1)
+            if "built" in line.lower():
+                match = re.search(r"built\s+(?:on\s+)?(.+?)(?:,|$)", line, re.IGNORECASE)
+                if match:
+                    built_at = match.group(1).strip()
+            if "commit" in line.lower():
+                match = re.search(r"commit\s+(\w+)", line, re.IGNORECASE)
+                if match:
+                    commit = match.group(1)
+
+        return cls(version=version, built_at=built_at, commit=commit)
+
+
+@dataclass
+class ButlerPushResult:
+    """Result of a butler push operation."""
+
+    success: bool
+    target: str
+    channel: str
+    version: str | None = None
+    build_id: int | None = None
+    signature_path: str | None = None
+    error: str | None = None
+    output: str = ""
+
+
+@dataclass
+class ButlerStatusResult:
+    """Result of a butler status operation."""
+
+    success: bool
+    target: str
+    channels: dict[str, dict[str, object]] = None  # type: ignore[assignment]
+    error: str | None = None
+    output: str = ""
+
+    def __post_init__(self) -> None:
+        """Initialize default values."""
+        if self.channels is None:
+            self.channels = {}
 
 
 class ButlerCLI:
@@ -13,15 +102,41 @@ class ButlerCLI:
 
     Butler is itch.io's command-line tool for uploading games
     and managing releases.
+
+    Example:
+        butler = ButlerCLI()
+        if not butler.check_installed():
+            await butler.download_butler()
+        result = await butler.push(Path("./build"), "username/game", "html5")
     """
 
-    def __init__(self, butler_path: str = "butler") -> None:
+    # Butler download URLs by platform
+    DOWNLOAD_URLS: ClassVar[dict[str, str]] = {
+        "darwin_x64": "https://broth.itch.ovh/butler/darwin-amd64/LATEST/archive/default",
+        "darwin_arm64": "https://broth.itch.ovh/butler/darwin-arm64/LATEST/archive/default",
+        "linux_x64": "https://broth.itch.ovh/butler/linux-amd64/LATEST/archive/default",
+        "windows_x64": "https://broth.itch.ovh/butler/windows-amd64/LATEST/archive/default",
+    }
+
+    def __init__(
+        self,
+        butler_path: str | Path | None = None,
+        timeout: float = 300.0,
+    ) -> None:
         """Initialize the butler wrapper.
 
         Args:
             butler_path: Path to the butler executable.
+                        If None, uses 'butler' from PATH or downloads it.
+            timeout: Default timeout for butler operations in seconds.
         """
-        self.butler_path = butler_path
+        if butler_path is None:
+            # Try to find butler in PATH
+            found = shutil.which("butler")
+            self.butler_path = Path(found) if found else Path("butler")
+        else:
+            self.butler_path = Path(butler_path)
+        self.timeout = timeout
 
     def check_installed(self) -> bool:
         """Check if butler is installed and accessible.
@@ -31,45 +146,451 @@ class ButlerCLI:
         """
         try:
             result = subprocess.run(
-                [self.butler_path, "version"],
+                [str(self.butler_path), "version"],
                 capture_output=True,
                 text=True,
                 timeout=10,
             )
             return result.returncode == 0
-        except (subprocess.SubprocessError, FileNotFoundError):
+        except (subprocess.SubprocessError, FileNotFoundError, OSError):
             return False
 
-    def push(
+    def get_version(self) -> ButlerVersion | None:
+        """Get butler version information.
+
+        Returns:
+            Version information, or None if butler is not installed.
+        """
+        try:
+            result = subprocess.run(
+                [str(self.butler_path), "version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode != 0:
+                return None
+            return ButlerVersion.from_output(result.stdout)
+        except (subprocess.SubprocessError, FileNotFoundError, OSError):
+            return None
+
+    def is_logged_in(self) -> bool:
+        """Check if butler is logged in to itch.io.
+
+        Returns:
+            True if logged in.
+        """
+        try:
+            result = subprocess.run(
+                [str(self.butler_path), "login", "--check"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            return result.returncode == 0
+        except (subprocess.SubprocessError, FileNotFoundError, OSError):
+            return False
+
+    @staticmethod
+    def _get_platform_key() -> str:
+        """Get the platform key for downloading butler.
+
+        Returns:
+            Platform key string.
+
+        Raises:
+            RuntimeError: If platform is not supported.
+        """
+        system = platform.system().lower()
+        machine = platform.machine().lower()
+
+        if system == "darwin":
+            if machine in ("arm64", "aarch64"):
+                return "darwin_arm64"
+            return "darwin_x64"
+        elif system == "linux":
+            return "linux_x64"
+        elif system == "windows":
+            return "windows_x64"
+        else:
+            raise RuntimeError(f"Unsupported platform: {system} {machine}")
+
+    async def download_butler(
+        self,
+        install_dir: Path | None = None,
+        *,
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> Path:
+        """Download and install butler.
+
+        Args:
+            install_dir: Directory to install butler to.
+                        Defaults to ~/.game-workflow/bin/
+            progress_callback: Callback for download progress (bytes_downloaded, total_bytes).
+
+        Returns:
+            Path to the installed butler executable.
+
+        Raises:
+            RuntimeError: If download or installation fails.
+        """
+        if install_dir is None:
+            install_dir = Path.home() / ".game-workflow" / "bin"
+
+        install_dir.mkdir(parents=True, exist_ok=True)
+
+        platform_key = self._get_platform_key()
+        url = self.DOWNLOAD_URLS.get(platform_key)
+        if url is None:
+            raise RuntimeError(f"No butler download URL for platform: {platform_key}")
+
+        logger.info("Downloading butler for %s from %s", platform_key, url)
+
+        try:
+            async with httpx.AsyncClient(follow_redirects=True) as client:
+                # Get the download URL (may redirect)
+                response = await client.get(url)
+                response.raise_for_status()
+
+                # The response is a zip file
+                content = response.content
+                total_bytes = len(content)
+
+                if progress_callback:
+                    progress_callback(total_bytes, total_bytes)
+
+            # Extract the zip file
+            import zipfile
+            from io import BytesIO
+
+            with zipfile.ZipFile(BytesIO(content)) as zf:
+                # Find the butler executable
+                butler_name = "butler.exe" if platform.system() == "Windows" else "butler"
+                for name in zf.namelist():
+                    if name.endswith(butler_name) or name == butler_name:
+                        # Extract to install directory
+                        zf.extract(name, install_dir)
+                        butler_path = install_dir / name
+                        break
+                else:
+                    # Butler is directly in the zip without subdirectory
+                    zf.extractall(install_dir)
+                    butler_path = install_dir / butler_name
+
+            # Make executable on Unix
+            if platform.system() != "Windows":
+                butler_path.chmod(butler_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+            # Update our path
+            self.butler_path = butler_path
+
+            logger.info("Butler installed to %s", butler_path)
+            return butler_path
+
+        except Exception as e:
+            raise RuntimeError(f"Failed to download butler: {e}") from e
+
+    async def login(self, api_key: str | None = None) -> bool:
+        """Log in to itch.io.
+
+        Args:
+            api_key: API key for authentication.
+                    If None, uses ITCHIO_API_KEY environment variable.
+
+        Returns:
+            True if login successful.
+
+        Note:
+            If no API key is provided, butler will open a browser
+            for interactive login.
+        """
+        if api_key is None:
+            api_key = os.environ.get("ITCHIO_API_KEY")
+
+        if api_key:
+            # Use API key login
+            env = os.environ.copy()
+            env["BUTLER_API_KEY"] = api_key
+
+            result = await asyncio.get_event_loop().run_in_executor(
+                None,
+                lambda: subprocess.run(
+                    [str(self.butler_path), "login"],
+                    capture_output=True,
+                    text=True,
+                    env=env,
+                    timeout=30,
+                ),
+            )
+            return result.returncode == 0
+        else:
+            # Interactive login - this won't work in automated environments
+            logger.warning("No API key provided, butler login requires interactive session")
+            return False
+
+    async def push(
         self,
         directory: Path,
         target: str,
         channel: str = "html5",
-    ) -> dict[str, str]:
+        *,
+        version: str | None = None,
+        fix_permissions: bool = True,
+        dry_run: bool = False,
+        progress_callback: Callable[[str], None] | None = None,
+    ) -> ButlerPushResult:
         """Push a game build to itch.io.
 
         Args:
             directory: Directory containing the game build.
             target: The itch.io target (username/game-name).
-            channel: The release channel.
+            channel: The release channel (e.g., "html5", "windows", "linux").
+            version: Version string for this upload.
+            fix_permissions: Whether to fix file permissions.
+            dry_run: If True, validate but don't actually upload.
+            progress_callback: Callback for progress updates.
 
         Returns:
-            Dict with upload results.
-
-        Raises:
-            RuntimeError: If the upload fails.
+            Result of the push operation.
         """
-        # TODO: Implement butler push
-        raise NotImplementedError("Butler push not yet implemented")
+        if not directory.exists():
+            return ButlerPushResult(
+                success=False,
+                target=target,
+                channel=channel,
+                error=f"Directory does not exist: {directory}",
+            )
 
-    def status(self, target: str) -> dict[str, str]:
+        if not directory.is_dir():
+            return ButlerPushResult(
+                success=False,
+                target=target,
+                channel=channel,
+                error=f"Path is not a directory: {directory}",
+            )
+
+        # Build command
+        cmd = [str(self.butler_path), "push"]
+
+        if fix_permissions:
+            cmd.append("--fix-permissions")
+
+        if dry_run:
+            cmd.append("--dry-run")
+
+        if version:
+            cmd.extend(["--userversion", version])
+
+        # Add directory and target:channel
+        cmd.append(str(directory))
+        cmd.append(f"{target}:{channel}")
+
+        logger.info("Running butler push: %s", " ".join(cmd))
+
+        try:
+            # Run with streaming output
+            process = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+
+            output_lines: list[str] = []
+            build_id = None
+
+            if process.stdout:
+                while True:
+                    line = await process.stdout.readline()
+                    if not line:
+                        break
+                    line_str = line.decode("utf-8", errors="replace").strip()
+                    output_lines.append(line_str)
+                    logger.debug("butler: %s", line_str)
+
+                    if progress_callback:
+                        progress_callback(line_str)
+
+                    # Try to extract build ID from output
+                    if "Build ID" in line_str:
+                        match = re.search(r"Build ID:\s*(\d+)", line_str)
+                        if match:
+                            build_id = int(match.group(1))
+
+            await process.wait()
+            output = "\n".join(output_lines)
+
+            if process.returncode == 0:
+                return ButlerPushResult(
+                    success=True,
+                    target=target,
+                    channel=channel,
+                    version=version,
+                    build_id=build_id,
+                    output=output,
+                )
+            else:
+                return ButlerPushResult(
+                    success=False,
+                    target=target,
+                    channel=channel,
+                    version=version,
+                    error=f"butler push failed with exit code {process.returncode}",
+                    output=output,
+                )
+
+        except TimeoutError:
+            return ButlerPushResult(
+                success=False,
+                target=target,
+                channel=channel,
+                version=version,
+                error="butler push timed out",
+            )
+        except Exception as e:
+            return ButlerPushResult(
+                success=False,
+                target=target,
+                channel=channel,
+                version=version,
+                error=str(e),
+            )
+
+    async def status(self, target: str) -> ButlerStatusResult:
         """Get the status of an itch.io game.
 
         Args:
             target: The itch.io target (username/game-name).
 
         Returns:
-            Dict with game status.
+            Status information for the game.
         """
-        # TODO: Implement butler status
-        raise NotImplementedError("Butler status not yet implemented")
+        cmd = [str(self.butler_path), "status", target]
+
+        logger.info("Running butler status: %s", " ".join(cmd))
+
+        try:
+            result = await asyncio.get_event_loop().run_in_executor(
+                None,
+                lambda: subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=self.timeout,
+                ),
+            )
+
+            if result.returncode != 0:
+                return ButlerStatusResult(
+                    success=False,
+                    target=target,
+                    error=result.stderr or f"butler status failed with exit code {result.returncode}",
+                    output=result.stdout,
+                )
+
+            # Parse the output to extract channel information
+            channels: dict[str, dict[str, object]] = {}
+            current_channel = None
+
+            for line in result.stdout.split("\n"):
+                line = line.strip()
+                if not line:
+                    continue
+
+                # Channel header: "Channel: html5"
+                if line.startswith("Channel:"):
+                    current_channel = line.split(":", 1)[1].strip()
+                    channels[current_channel] = {}
+                elif current_channel and ":" in line:
+                    key, value = line.split(":", 1)
+                    channels[current_channel][key.strip().lower().replace(" ", "_")] = value.strip()
+
+            return ButlerStatusResult(
+                success=True,
+                target=target,
+                channels=channels,
+                output=result.stdout,
+            )
+
+        except TimeoutError:
+            return ButlerStatusResult(
+                success=False,
+                target=target,
+                error="butler status timed out",
+            )
+        except Exception as e:
+            return ButlerStatusResult(
+                success=False,
+                target=target,
+                error=str(e),
+            )
+
+    async def fetch(
+        self,
+        target: str,
+        output_dir: Path,
+        *,
+        channel: str | None = None,
+    ) -> bool:
+        """Fetch a game build from itch.io.
+
+        Args:
+            target: The itch.io target (username/game-name).
+            output_dir: Directory to download to.
+            channel: Specific channel to fetch (optional).
+
+        Returns:
+            True if fetch was successful.
+        """
+        cmd = [str(self.butler_path), "fetch"]
+
+        fetch_target = target
+        if channel:
+            fetch_target = f"{target}:{channel}"
+
+        cmd.extend([fetch_target, str(output_dir)])
+
+        logger.info("Running butler fetch: %s", " ".join(cmd))
+
+        try:
+            result = await asyncio.get_event_loop().run_in_executor(
+                None,
+                lambda: subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=self.timeout,
+                ),
+            )
+            return result.returncode == 0
+
+        except (TimeoutError, subprocess.SubprocessError):
+            return False
+
+    async def validate(self, directory: Path) -> tuple[bool, str]:
+        """Validate a game directory.
+
+        Args:
+            directory: Directory to validate.
+
+        Returns:
+            Tuple of (is_valid, message).
+        """
+        if not directory.exists():
+            return False, f"Directory does not exist: {directory}"
+
+        if not directory.is_dir():
+            return False, f"Path is not a directory: {directory}"
+
+        # Check for common game files
+        has_index = (directory / "index.html").exists()
+        has_any_files = any(directory.iterdir())
+
+        if not has_any_files:
+            return False, "Directory is empty"
+
+        # For HTML5 games, check for index.html
+        if has_index:
+            return True, "Valid HTML5 game (index.html found)"
+
+        # Check for other common patterns
+        return True, "Directory contains files"

--- a/src/game_workflow/mcp_servers/itchio/server.py
+++ b/src/game_workflow/mcp_servers/itchio/server.py
@@ -1,18 +1,412 @@
 """MCP server implementation for itch.io.
 
-This module implements the MCP server protocol for itch.io operations.
+This module implements the MCP server protocol for itch.io operations,
+providing tools for uploading games, managing store pages, and publishing.
 """
 
-# TODO: Implement MCP server using mcp library
-# from mcp import Server, Tool
+from __future__ import annotations
 
-# server = Server("itchio")
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import (
+    INTERNAL_ERROR,
+    INVALID_PARAMS,
+    CallToolResult,
+    TextContent,
+    Tool,
+)
+from pydantic import BaseModel, Field
+
+from game_workflow.mcp_servers.itchio.api import ItchioAPI
+from game_workflow.mcp_servers.itchio.butler import ButlerCLI
+
+logger = logging.getLogger(__name__)
+
+
+# Tool parameter schemas
+class UploadGameParams(BaseModel):
+    """Parameters for upload_game tool."""
+
+    directory: str = Field(description="Path to the directory containing the game build")
+    target: str = Field(description="itch.io target in format 'username/game-name'")
+    channel: str = Field(default="html5", description="Release channel (e.g., html5, windows, linux)")
+    version: str | None = Field(default=None, description="Version string for this upload")
+    dry_run: bool = Field(default=False, description="If true, validate but don't actually upload")
+
+
+class UpdateGamePageParams(BaseModel):
+    """Parameters for update_game_page tool."""
+
+    target: str = Field(description="itch.io target in format 'username/game-name'")
+    title: str | None = Field(default=None, description="New game title")
+    short_description: str | None = Field(default=None, description="Short description (tagline)")
+    description: str | None = Field(default=None, description="Full game description (HTML or Markdown)")
+
+
+class PublishGameParams(BaseModel):
+    """Parameters for publish_game tool."""
+
+    target: str = Field(description="itch.io target in format 'username/game-name'")
+    channel: str = Field(default="html5", description="Channel to publish")
+
+
+class GetGameStatusParams(BaseModel):
+    """Parameters for get_game_status tool."""
+
+    target: str = Field(description="itch.io target in format 'username/game-name'")
+
+
+class GetMyGamesParams(BaseModel):
+    """Parameters for get_my_games tool."""
+
+    pass
+
+
+class CheckCredentialsParams(BaseModel):
+    """Parameters for check_credentials tool."""
+
+    pass
+
+
+# Create the MCP server
+server = Server("itchio")
+
+
+def _create_error_response(message: str, code: str = INTERNAL_ERROR) -> list[TextContent]:
+    """Create an error response.
+
+    Args:
+        message: Error message.
+        code: Error code.
+
+    Returns:
+        List containing error text content.
+    """
+    return [TextContent(type="text", text=json.dumps({"error": message, "code": code}))]
+
+
+def _create_success_response(data: dict[str, Any]) -> list[TextContent]:
+    """Create a success response.
+
+    Args:
+        data: Response data.
+
+    Returns:
+        List containing success text content.
+    """
+    return [TextContent(type="text", text=json.dumps({"success": True, **data}))]
+
+
+@server.list_tools()
+async def list_tools() -> list[Tool]:
+    """List available itch.io tools."""
+    return [
+        Tool(
+            name="upload_game",
+            description="Upload a game build to itch.io using butler. "
+                       "Requires a built game directory and an itch.io target (username/game-name).",
+            inputSchema=UploadGameParams.model_json_schema(),
+        ),
+        Tool(
+            name="get_game_status",
+            description="Get the current status of a game on itch.io, including all channels and uploads.",
+            inputSchema=GetGameStatusParams.model_json_schema(),
+        ),
+        Tool(
+            name="get_my_games",
+            description="Get a list of all games owned by the authenticated user.",
+            inputSchema=GetMyGamesParams.model_json_schema(),
+        ),
+        Tool(
+            name="check_credentials",
+            description="Check if the itch.io API credentials are valid and return user information.",
+            inputSchema=CheckCredentialsParams.model_json_schema(),
+        ),
+    ]
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict[str, Any]) -> CallToolResult:
+    """Handle tool calls.
+
+    Args:
+        name: Tool name.
+        arguments: Tool arguments.
+
+    Returns:
+        Tool result.
+    """
+    try:
+        if name == "upload_game":
+            return await _upload_game(arguments)
+        elif name == "get_game_status":
+            return await _get_game_status(arguments)
+        elif name == "get_my_games":
+            return await _get_my_games(arguments)
+        elif name == "check_credentials":
+            return await _check_credentials(arguments)
+        else:
+            return CallToolResult(
+                content=_create_error_response(f"Unknown tool: {name}", INVALID_PARAMS),
+                isError=True,
+            )
+    except Exception as e:
+        logger.exception("Error in tool %s", name)
+        return CallToolResult(
+            content=_create_error_response(str(e)),
+            isError=True,
+        )
+
+
+async def _upload_game(arguments: dict[str, Any]) -> CallToolResult:
+    """Handle upload_game tool.
+
+    Args:
+        arguments: Tool arguments.
+
+    Returns:
+        Tool result.
+    """
+    try:
+        params = UploadGameParams(**arguments)
+    except Exception as e:
+        return CallToolResult(
+            content=_create_error_response(f"Invalid parameters: {e}", INVALID_PARAMS),
+            isError=True,
+        )
+
+    directory = Path(params.directory)
+
+    # Validate directory
+    if not directory.exists():
+        return CallToolResult(
+            content=_create_error_response(f"Directory does not exist: {directory}"),
+            isError=True,
+        )
+
+    if not directory.is_dir():
+        return CallToolResult(
+            content=_create_error_response(f"Path is not a directory: {directory}"),
+            isError=True,
+        )
+
+    # Initialize butler
+    butler = ButlerCLI()
+
+    # Check if butler is installed
+    if not butler.check_installed():
+        return CallToolResult(
+            content=_create_error_response(
+                "Butler CLI is not installed. Please install butler first: "
+                "https://itch.io/docs/butler/installing.html"
+            ),
+            isError=True,
+        )
+
+    # Validate directory contents
+    is_valid, validation_message = await butler.validate(directory)
+    if not is_valid:
+        return CallToolResult(
+            content=_create_error_response(f"Invalid game directory: {validation_message}"),
+            isError=True,
+        )
+
+    # Push the game
+    result = await butler.push(
+        directory=directory,
+        target=params.target,
+        channel=params.channel,
+        version=params.version,
+        dry_run=params.dry_run,
+    )
+
+    if result.success:
+        return CallToolResult(
+            content=_create_success_response({
+                "target": result.target,
+                "channel": result.channel,
+                "version": result.version,
+                "build_id": result.build_id,
+                "dry_run": params.dry_run,
+                "message": f"Successfully uploaded to {result.target}:{result.channel}",
+            }),
+        )
+    else:
+        return CallToolResult(
+            content=_create_error_response(result.error or "Upload failed"),
+            isError=True,
+        )
+
+
+async def _get_game_status(arguments: dict[str, Any]) -> CallToolResult:
+    """Handle get_game_status tool.
+
+    Args:
+        arguments: Tool arguments.
+
+    Returns:
+        Tool result.
+    """
+    try:
+        params = GetGameStatusParams(**arguments)
+    except Exception as e:
+        return CallToolResult(
+            content=_create_error_response(f"Invalid parameters: {e}", INVALID_PARAMS),
+            isError=True,
+        )
+
+    # Initialize butler
+    butler = ButlerCLI()
+
+    if not butler.check_installed():
+        return CallToolResult(
+            content=_create_error_response(
+                "Butler CLI is not installed. Please install butler first: "
+                "https://itch.io/docs/butler/installing.html"
+            ),
+            isError=True,
+        )
+
+    # Get status
+    result = await butler.status(params.target)
+
+    if result.success:
+        return CallToolResult(
+            content=_create_success_response({
+                "target": result.target,
+                "channels": result.channels,
+            }),
+        )
+    else:
+        return CallToolResult(
+            content=_create_error_response(result.error or "Failed to get status"),
+            isError=True,
+        )
+
+
+async def _get_my_games(
+    arguments: dict[str, Any],  # noqa: ARG001
+) -> CallToolResult:
+    """Handle get_my_games tool.
+
+    Args:
+        arguments: Tool arguments (unused, no parameters needed).
+
+    Returns:
+        Tool result.
+    """
+    api_key = os.environ.get("ITCHIO_API_KEY")
+    if not api_key:
+        return CallToolResult(
+            content=_create_error_response("ITCHIO_API_KEY environment variable is not set"),
+            isError=True,
+        )
+
+    async with ItchioAPI(api_key=api_key) as api:
+        games = await api.get_my_games()
+
+        games_data = []
+        for game in games:
+            games_data.append({
+                "id": game.id,
+                "title": game.title,
+                "url": game.url,
+                "short_text": game.short_text,
+                "classification": game.classification.value,
+                "downloads_count": game.downloads_count,
+                "views_count": game.views_count,
+            })
+
+        return CallToolResult(
+            content=_create_success_response({
+                "games": games_data,
+                "count": len(games_data),
+            }),
+        )
+
+
+async def _check_credentials(
+    arguments: dict[str, Any],  # noqa: ARG001
+) -> CallToolResult:
+    """Handle check_credentials tool.
+
+    Args:
+        arguments: Tool arguments (unused, no parameters needed).
+
+    Returns:
+        Tool result.
+    """
+    api_key = os.environ.get("ITCHIO_API_KEY")
+    if not api_key:
+        return CallToolResult(
+            content=_create_error_response("ITCHIO_API_KEY environment variable is not set"),
+            isError=True,
+        )
+
+    # Check butler
+    butler = ButlerCLI()
+    butler_installed = butler.check_installed()
+    butler_version = None
+    butler_logged_in = False
+
+    if butler_installed:
+        version_info = butler.get_version()
+        if version_info:
+            butler_version = version_info.version
+        butler_logged_in = butler.is_logged_in()
+
+    # Check API
+    async with ItchioAPI(api_key=api_key) as api:
+        user = await api.get_me()
+
+        if user:
+            return CallToolResult(
+                content=_create_success_response({
+                    "api_valid": True,
+                    "user": {
+                        "id": user.id,
+                        "username": user.username,
+                        "display_name": user.display_name,
+                        "url": user.url,
+                        "developer": user.developer,
+                    },
+                    "butler": {
+                        "installed": butler_installed,
+                        "version": butler_version,
+                        "logged_in": butler_logged_in,
+                    },
+                }),
+            )
+        else:
+            return CallToolResult(
+                content=_create_error_response("Invalid API key or failed to authenticate"),
+                isError=True,
+            )
+
+
+async def run_server() -> None:
+    """Run the MCP server."""
+    logger.info("Starting itch.io MCP server")
+
+    async with stdio_server() as (read_stream, write_stream):
+        await server.run(
+            read_stream,
+            write_stream,
+            server.create_initialization_options(),
+        )
 
 
 def main() -> None:
     """Run the itch.io MCP server."""
-    # TODO: Implement server startup
-    raise NotImplementedError("itch.io MCP server not yet implemented")
+    logging.basicConfig(level=logging.INFO)
+    asyncio.run(run_server())
 
 
 if __name__ == "__main__":

--- a/src/game_workflow/mcp_servers/registry.py
+++ b/src/game_workflow/mcp_servers/registry.py
@@ -1,10 +1,18 @@
-"""MCP server registry for managing server configurations.
+"""MCP server registry for managing server configurations and lifecycle.
 
-This module provides a registry for MCP servers used by the workflow.
+This module provides a registry for MCP servers used by the workflow,
+including lifecycle management (start, stop, health checks).
 """
 
+from __future__ import annotations
+
+import asyncio
+import logging
 import os
+import subprocess
 from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -14,18 +22,55 @@ class MCPServerConfig:
     command: str
     args: list[str] = field(default_factory=list)
     env: dict[str, str] = field(default_factory=dict)
+    working_dir: str | None = None
+    startup_timeout: float = 30.0
+    health_check_interval: float = 10.0
+
+
+@dataclass
+class MCPServerProcess:
+    """Represents a running MCP server process."""
+
+    name: str
+    config: MCPServerConfig
+    process: subprocess.Popen[bytes] | None = None
+    started_at: float | None = None
+    healthy: bool = False
+
+    @property
+    def is_running(self) -> bool:
+        """Check if the process is running."""
+        if self.process is None:
+            return False
+        return self.process.poll() is None
+
+    @property
+    def pid(self) -> int | None:
+        """Get the process ID if running."""
+        if self.process is not None and self.is_running:
+            return self.process.pid
+        return None
 
 
 class MCPServerRegistry:
-    """Registry for MCP server configurations.
+    """Registry for MCP server configurations and lifecycle.
 
     Manages the configuration and lifecycle of MCP servers
     used by the workflow agents.
+
+    Example:
+        async with MCPServerRegistry() as registry:
+            await registry.start_server("github")
+            # Use the server...
+            await registry.stop_server("github")
     """
 
     def __init__(self) -> None:
         """Initialize the registry with default servers."""
         self._servers: dict[str, MCPServerConfig] = {}
+        self._processes: dict[str, MCPServerProcess] = {}
+        self._health_check_tasks: dict[str, asyncio.Task[None]] = {}
+        self._lock = asyncio.Lock()
         self._register_default_servers()
 
     def _register_default_servers(self) -> None:
@@ -54,6 +99,19 @@ class MCPServerRegistry:
             env={"ITCHIO_API_KEY": itchio_key},
         )
 
+    async def __aenter__(self) -> MCPServerRegistry:
+        """Enter async context."""
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: object,
+    ) -> None:
+        """Exit async context, stopping all servers."""
+        await self.stop_all()
+
     def get(self, name: str) -> MCPServerConfig | None:
         """Get a server configuration by name.
 
@@ -74,6 +132,25 @@ class MCPServerRegistry:
         """
         self._servers[name] = config
 
+    def unregister(self, name: str) -> bool:
+        """Unregister a server configuration.
+
+        Args:
+            name: The server name.
+
+        Returns:
+            True if the server was unregistered, False if not found.
+        """
+        if name in self._servers:
+            # Stop if running
+            if name in self._processes:
+                # Store the task reference to prevent garbage collection
+                task = asyncio.create_task(self.stop_server(name))
+                task.add_done_callback(lambda t: None)  # noqa: ARG005
+            del self._servers[name]
+            return True
+        return False
+
     def list_servers(self) -> list[str]:
         """List all registered server names.
 
@@ -81,3 +158,346 @@ class MCPServerRegistry:
             List of server names.
         """
         return list(self._servers.keys())
+
+    def list_running(self) -> list[str]:
+        """List all running server names.
+
+        Returns:
+            List of running server names.
+        """
+        return [
+            name for name, proc in self._processes.items()
+            if proc.is_running
+        ]
+
+    def is_running(self, name: str) -> bool:
+        """Check if a server is running.
+
+        Args:
+            name: The server name.
+
+        Returns:
+            True if the server is running.
+        """
+        proc = self._processes.get(name)
+        return proc is not None and proc.is_running
+
+    def is_healthy(self, name: str) -> bool:
+        """Check if a server is healthy.
+
+        Args:
+            name: The server name.
+
+        Returns:
+            True if the server is running and healthy.
+        """
+        proc = self._processes.get(name)
+        return proc is not None and proc.is_running and proc.healthy
+
+    def get_process(self, name: str) -> MCPServerProcess | None:
+        """Get the process info for a server.
+
+        Args:
+            name: The server name.
+
+        Returns:
+            The server process info, or None if not running.
+        """
+        return self._processes.get(name)
+
+    async def start_server(
+        self,
+        name: str,
+        *,
+        wait_healthy: bool = True,
+        timeout: float | None = None,
+    ) -> MCPServerProcess:
+        """Start an MCP server.
+
+        Args:
+            name: The server name.
+            wait_healthy: Whether to wait for health check.
+            timeout: Timeout for startup (uses config default if None).
+
+        Returns:
+            The server process info.
+
+        Raises:
+            ValueError: If the server is not registered.
+            RuntimeError: If the server fails to start.
+        """
+        config = self._servers.get(name)
+        if config is None:
+            raise ValueError(f"Server '{name}' is not registered")
+
+        async with self._lock:
+            # Check if already running
+            if name in self._processes and self._processes[name].is_running:
+                logger.info("Server '%s' is already running", name)
+                return self._processes[name]
+
+            # Build environment
+            env = os.environ.copy()
+            env.update(config.env)
+
+            # Build command
+            cmd = [config.command, *config.args]
+
+            logger.info("Starting MCP server '%s': %s", name, " ".join(cmd))
+
+            try:
+                import time
+
+                process = subprocess.Popen(
+                    cmd,
+                    env=env,
+                    cwd=config.working_dir,
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                )
+
+                proc_info = MCPServerProcess(
+                    name=name,
+                    config=config,
+                    process=process,
+                    started_at=time.time(),
+                    healthy=False,
+                )
+
+                self._processes[name] = proc_info
+
+                # Wait for process to stabilize
+                await asyncio.sleep(0.1)
+
+                if not proc_info.is_running:
+                    # Process exited immediately
+                    stderr = ""
+                    if process.stderr:
+                        stderr = process.stderr.read().decode("utf-8", errors="replace")
+                    raise RuntimeError(
+                        f"Server '{name}' exited immediately: {stderr}"
+                    )
+
+                if wait_healthy:
+                    startup_timeout = timeout or config.startup_timeout
+                    await self._wait_healthy(name, timeout=startup_timeout)
+
+                # Start health check task
+                self._start_health_check(name)
+
+                logger.info("Server '%s' started successfully (PID: %s)", name, proc_info.pid)
+                return proc_info
+
+            except Exception as e:
+                # Clean up on failure
+                if name in self._processes:
+                    del self._processes[name]
+                raise RuntimeError(f"Failed to start server '{name}': {e}") from e
+
+    async def stop_server(self, name: str, *, timeout: float = 10.0) -> bool:
+        """Stop an MCP server.
+
+        Args:
+            name: The server name.
+            timeout: Timeout for graceful shutdown.
+
+        Returns:
+            True if the server was stopped, False if not running.
+        """
+        async with self._lock:
+            proc_info = self._processes.get(name)
+            if proc_info is None or not proc_info.is_running:
+                logger.debug("Server '%s' is not running", name)
+                if name in self._processes:
+                    del self._processes[name]
+                return False
+
+            # Cancel health check
+            self._stop_health_check(name)
+
+            process = proc_info.process
+            if process is None:
+                return False
+
+            logger.info("Stopping MCP server '%s' (PID: %s)", name, process.pid)
+
+            try:
+                # Try graceful shutdown first
+                process.terminate()
+
+                # Wait for graceful shutdown
+                try:
+                    await asyncio.wait_for(
+                        asyncio.get_event_loop().run_in_executor(
+                            None, process.wait
+                        ),
+                        timeout=timeout,
+                    )
+                except TimeoutError:
+                    # Force kill
+                    logger.warning("Server '%s' did not stop gracefully, killing", name)
+                    process.kill()
+                    process.wait()
+
+                logger.info("Server '%s' stopped", name)
+                del self._processes[name]
+                return True
+
+            except Exception as e:
+                logger.error("Error stopping server '%s': %s", name, e)
+                if name in self._processes:
+                    del self._processes[name]
+                return False
+
+    async def restart_server(
+        self,
+        name: str,
+        *,
+        stop_timeout: float = 10.0,
+        wait_healthy: bool = True,
+        start_timeout: float | None = None,
+    ) -> MCPServerProcess:
+        """Restart an MCP server.
+
+        Args:
+            name: The server name.
+            stop_timeout: Timeout for stopping.
+            wait_healthy: Whether to wait for health check.
+            start_timeout: Timeout for startup.
+
+        Returns:
+            The new server process info.
+        """
+        await self.stop_server(name, timeout=stop_timeout)
+        return await self.start_server(
+            name, wait_healthy=wait_healthy, timeout=start_timeout
+        )
+
+    async def stop_all(self, *, timeout: float = 10.0) -> None:
+        """Stop all running servers.
+
+        Args:
+            timeout: Timeout for each server shutdown.
+        """
+        running = self.list_running()
+        if not running:
+            return
+
+        logger.info("Stopping %d MCP servers", len(running))
+
+        # Stop all servers concurrently
+        await asyncio.gather(
+            *[self.stop_server(name, timeout=timeout) for name in running],
+            return_exceptions=True,
+        )
+
+    async def _wait_healthy(
+        self,
+        name: str,
+        timeout: float = 30.0,  # noqa: ARG002
+    ) -> None:
+        """Wait for a server to become healthy.
+
+        Args:
+            name: The server name.
+            timeout: Maximum time to wait (reserved for future health check logic).
+
+        Raises:
+            RuntimeError: If the server fails to become healthy.
+        """
+        proc_info = self._processes.get(name)
+        if proc_info is None:
+            raise RuntimeError(f"Server '{name}' is not running")
+
+        # Check if process is still running
+        if not proc_info.is_running:
+            raise RuntimeError(f"Server '{name}' exited unexpectedly")
+
+        # Simple health check: process is running
+        # In a real implementation, you'd do an actual health check RPC
+        proc_info.healthy = True
+
+        # Future: implement actual health check loop with timeout
+        # start_time = asyncio.get_event_loop().time()
+        # while True:
+        #     elapsed = asyncio.get_event_loop().time() - start_time
+        #     if elapsed >= timeout:
+            #     raise RuntimeError(f"Server '{name}' did not become healthy")
+            # await asyncio.sleep(0.5)
+
+    def _start_health_check(self, name: str) -> None:
+        """Start periodic health check for a server.
+
+        Args:
+            name: The server name.
+        """
+        # Cancel existing task if any
+        self._stop_health_check(name)
+
+        config = self._servers.get(name)
+        if config is None:
+            return
+
+        async def health_check_loop() -> None:
+            while True:
+                await asyncio.sleep(config.health_check_interval)
+                proc_info = self._processes.get(name)
+                if proc_info is None or not proc_info.is_running:
+                    break
+                # Simple health check: process is running
+                proc_info.healthy = proc_info.is_running
+
+        self._health_check_tasks[name] = asyncio.create_task(health_check_loop())
+
+    def _stop_health_check(self, name: str) -> None:
+        """Stop health check for a server.
+
+        Args:
+            name: The server name.
+        """
+        task = self._health_check_tasks.pop(name, None)
+        if task is not None:
+            task.cancel()
+
+    def get_server_stats(self, name: str) -> dict[str, object] | None:
+        """Get statistics for a server.
+
+        Args:
+            name: The server name.
+
+        Returns:
+            Dictionary with server stats, or None if not running.
+        """
+        import time
+
+        proc_info = self._processes.get(name)
+        if proc_info is None:
+            return None
+
+        uptime = None
+        if proc_info.started_at is not None:
+            uptime = time.time() - proc_info.started_at
+
+        return {
+            "name": name,
+            "running": proc_info.is_running,
+            "healthy": proc_info.healthy,
+            "pid": proc_info.pid,
+            "uptime_seconds": uptime,
+            "config": {
+                "command": proc_info.config.command,
+                "args": proc_info.config.args,
+            },
+        }
+
+    def get_all_stats(self) -> dict[str, dict[str, object] | None]:
+        """Get statistics for all servers.
+
+        Returns:
+            Dictionary mapping server names to stats.
+        """
+        return {
+            name: self.get_server_stats(name)
+            for name in self._servers
+        }

--- a/src/game_workflow/orchestrator/workflow.py
+++ b/src/game_workflow/orchestrator/workflow.py
@@ -10,8 +10,6 @@ import logging
 from typing import TYPE_CHECKING, Any, Protocol
 
 from game_workflow.config import get_settings
-from game_workflow.hooks.checkpoint import CheckpointHook
-from game_workflow.hooks.logging import LoggingHook
 from game_workflow.orchestrator.exceptions import WorkflowError
 from game_workflow.orchestrator.state import WorkflowPhase, WorkflowState
 
@@ -92,6 +90,10 @@ class Workflow:
 
     def _setup_default_hooks(self) -> None:
         """Set up the default workflow hooks."""
+        # Import here to avoid circular imports
+        from game_workflow.hooks.checkpoint import CheckpointHook
+        from game_workflow.hooks.logging import LoggingHook
+
         settings = get_settings()
 
         # Add logging hook

--- a/tests/integration/test_slack_integration.py
+++ b/tests/integration/test_slack_integration.py
@@ -1,0 +1,425 @@
+"""Integration tests for Slack approval hook.
+
+These tests require a valid SLACK_BOT_TOKEN environment variable
+and access to a test Slack workspace.
+
+Run with: pytest tests/integration/test_slack_integration.py -v
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# Import directly from the module to avoid circular import
+from game_workflow.hooks.slack_approval import (
+    ApprovalRequest,
+    ApprovalStatus,
+    SlackApprovalHook,
+    SlackClient,
+)
+
+
+class TestSlackClient:
+    """Unit tests for SlackClient (mocked)."""
+
+    def test_init_default_token(self) -> None:
+        """Test initialization with default token from env."""
+        with patch.dict(os.environ, {"SLACK_BOT_TOKEN": "xoxb-test-token"}):
+            client = SlackClient()
+            assert client.token == "xoxb-test-token"
+
+    def test_init_custom_token(self) -> None:
+        """Test initialization with custom token."""
+        client = SlackClient(token="custom-token")
+        assert client.token == "custom-token"
+
+    def test_init_custom_timeout(self) -> None:
+        """Test initialization with custom timeout."""
+        client = SlackClient(timeout=60.0)
+        assert client.timeout == 60.0
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self) -> None:
+        """Test async context manager creates and closes client."""
+        async with SlackClient(token="test-token") as client:
+            assert client._client is not None
+        assert client._client is None
+
+    @pytest.mark.asyncio
+    async def test_client_property(self) -> None:
+        """Test client property creates client if needed."""
+        client = SlackClient(token="test-token")
+        assert client._client is None
+        _ = client.client
+        assert client._client is not None
+        await client.close()
+
+
+class TestSlackApprovalHook:
+    """Tests for SlackApprovalHook."""
+
+    def test_init_defaults(self) -> None:
+        """Test initialization with defaults."""
+        hook = SlackApprovalHook()
+        assert hook.channel == "#game-dev"
+        assert hook.poll_interval == 5.0
+        assert hook.require_thread_reply is False
+
+    def test_init_custom_channel(self) -> None:
+        """Test initialization with custom channel."""
+        hook = SlackApprovalHook(channel="#custom-channel")
+        assert hook.channel == "#custom-channel"
+
+    def test_init_require_thread_reply(self) -> None:
+        """Test initialization with thread reply requirement."""
+        hook = SlackApprovalHook(require_thread_reply=True)
+        assert hook.require_thread_reply is True
+
+    def test_create_approval_blocks(self) -> None:
+        """Test approval blocks creation."""
+        hook = SlackApprovalHook()
+        blocks = hook._create_approval_blocks("Test message")
+
+        # Should have header, section, divider, context
+        assert len(blocks) >= 4
+        assert blocks[0]["type"] == "header"
+        assert "Approval Required" in blocks[0]["text"]["text"]
+
+    def test_create_approval_blocks_with_context(self) -> None:
+        """Test approval blocks with context dict."""
+        hook = SlackApprovalHook()
+        blocks = hook._create_approval_blocks(
+            "Test message",
+            context={"Game": "My Game", "Version": "1.0.0"},
+        )
+
+        # Should include context section
+        context_found = False
+        for block in blocks:
+            if block["type"] == "section":
+                text = block.get("text", {}).get("text", "")
+                if "Game" in text and "My Game" in text:
+                    context_found = True
+                    break
+        assert context_found
+
+    def test_create_approval_blocks_with_request_id(self) -> None:
+        """Test approval blocks with request ID."""
+        hook = SlackApprovalHook()
+        blocks = hook._create_approval_blocks("Test message", request_id="abc123")
+
+        # Should include request ID in context
+        request_id_found = False
+        for block in blocks:
+            if block["type"] == "context":
+                for element in block.get("elements", []):
+                    if "abc123" in element.get("text", ""):
+                        request_id_found = True
+                        break
+        assert request_id_found
+
+    def test_create_approval_blocks_thread_reply_instruction(self) -> None:
+        """Test approval blocks have thread reply instructions when required."""
+        hook = SlackApprovalHook(require_thread_reply=True)
+        blocks = hook._create_approval_blocks("Test message")
+
+        # Should have thread reply instructions
+        instruction_found = False
+        for block in blocks:
+            if block["type"] == "context":
+                for element in block.get("elements", []):
+                    if "Reply to this thread" in element.get("text", ""):
+                        instruction_found = True
+                        break
+        assert instruction_found
+
+    def test_create_response_blocks_approved(self) -> None:
+        """Test response blocks for approved status."""
+        hook = SlackApprovalHook()
+        blocks = hook._create_response_blocks(
+            "Original message",
+            ApprovalStatus.APPROVED,
+            responder="U12345",
+        )
+
+        assert len(blocks) >= 2
+        assert "Approved" in blocks[0]["text"]["text"]
+        assert "white_check_mark" in blocks[0]["text"]["text"]
+
+    def test_create_response_blocks_rejected(self) -> None:
+        """Test response blocks for rejected status."""
+        hook = SlackApprovalHook()
+        blocks = hook._create_response_blocks(
+            "Original message",
+            ApprovalStatus.REJECTED,
+            responder="U12345",
+            feedback="Not ready yet",
+        )
+
+        assert len(blocks) >= 3
+        assert "Rejected" in blocks[0]["text"]["text"]
+        # Should include feedback
+        feedback_found = False
+        for block in blocks:
+            if "Feedback" in str(block):
+                feedback_found = True
+                break
+        assert feedback_found
+
+    def test_check_reactions_approve(self) -> None:
+        """Test checking reactions for approval."""
+        hook = SlackApprovalHook()
+        reactions = [{"name": "white_check_mark", "users": ["U12345"]}]
+        status, responder = hook._check_reactions(reactions)
+        assert status == ApprovalStatus.APPROVED
+        assert responder == "U12345"
+
+    def test_check_reactions_reject(self) -> None:
+        """Test checking reactions for rejection."""
+        hook = SlackApprovalHook()
+        reactions = [{"name": "x", "users": ["U12345"]}]
+        status, responder = hook._check_reactions(reactions)
+        assert status == ApprovalStatus.REJECTED
+        assert responder == "U12345"
+
+    def test_check_reactions_thumbsup(self) -> None:
+        """Test checking thumbsup reaction."""
+        hook = SlackApprovalHook()
+        reactions = [{"name": "thumbsup", "users": ["U12345"]}]
+        status, _responder = hook._check_reactions(reactions)
+        assert status == ApprovalStatus.APPROVED
+
+    def test_check_reactions_no_users(self) -> None:
+        """Test checking reactions with no users."""
+        hook = SlackApprovalHook()
+        reactions = [{"name": "white_check_mark", "users": []}]
+        status, responder = hook._check_reactions(reactions)
+        assert status is None
+        assert responder is None
+
+    def test_check_reactions_unknown(self) -> None:
+        """Test checking reactions with unknown emoji."""
+        hook = SlackApprovalHook()
+        reactions = [{"name": "smile", "users": ["U12345"]}]
+        status, responder = hook._check_reactions(reactions)
+        assert status is None
+        assert responder is None
+
+    def test_check_reactions_empty(self) -> None:
+        """Test checking empty reactions."""
+        hook = SlackApprovalHook()
+        status, responder = hook._check_reactions([])
+        assert status is None
+        assert responder is None
+
+    def test_check_replies_approve(self) -> None:
+        """Test checking replies for approval."""
+        hook = SlackApprovalHook()
+        replies = [{"text": "approve", "user": "U12345"}]
+        status, responder, feedback = hook._check_replies(replies)
+        assert status == ApprovalStatus.APPROVED
+        assert responder == "U12345"
+        assert feedback is None
+
+    def test_check_replies_approve_with_feedback(self) -> None:
+        """Test checking replies for approval with feedback."""
+        hook = SlackApprovalHook()
+        replies = [{"text": "approve looks good!", "user": "U12345"}]
+        status, responder, feedback = hook._check_replies(replies)
+        assert status == ApprovalStatus.APPROVED
+        assert responder == "U12345"
+        assert feedback == "looks good!"
+
+    def test_check_replies_reject(self) -> None:
+        """Test checking replies for rejection."""
+        hook = SlackApprovalHook()
+        replies = [{"text": "reject", "user": "U12345"}]
+        status, responder, _feedback = hook._check_replies(replies)
+        assert status == ApprovalStatus.REJECTED
+        assert responder == "U12345"
+
+    def test_check_replies_reject_with_feedback(self) -> None:
+        """Test checking replies for rejection with feedback."""
+        hook = SlackApprovalHook()
+        replies = [{"text": "reject needs more testing", "user": "U12345"}]
+        status, _responder, feedback = hook._check_replies(replies)
+        assert status == ApprovalStatus.REJECTED
+        assert feedback == "needs more testing"
+
+    def test_check_replies_yes(self) -> None:
+        """Test checking replies with 'yes'."""
+        hook = SlackApprovalHook()
+        replies = [{"text": "yes", "user": "U12345"}]
+        status, _responder, _feedback = hook._check_replies(replies)
+        assert status == ApprovalStatus.APPROVED
+
+    def test_check_replies_lgtm(self) -> None:
+        """Test checking replies with 'lgtm'."""
+        hook = SlackApprovalHook()
+        replies = [{"text": "lgtm", "user": "U12345"}]
+        status, _responder, _feedback = hook._check_replies(replies)
+        assert status == ApprovalStatus.APPROVED
+
+    def test_check_replies_no(self) -> None:
+        """Test checking replies with 'no'."""
+        hook = SlackApprovalHook()
+        replies = [{"text": "no", "user": "U12345"}]
+        status, _responder, _feedback = hook._check_replies(replies)
+        assert status == ApprovalStatus.REJECTED
+
+    def test_check_replies_stop(self) -> None:
+        """Test checking replies with 'stop'."""
+        hook = SlackApprovalHook()
+        replies = [{"text": "stop", "user": "U12345"}]
+        status, _responder, _feedback = hook._check_replies(replies)
+        assert status == ApprovalStatus.REJECTED
+
+    def test_check_replies_empty(self) -> None:
+        """Test checking empty replies."""
+        hook = SlackApprovalHook()
+        status, responder, feedback = hook._check_replies([])
+        assert status is None
+        assert responder is None
+        assert feedback is None
+
+    def test_check_replies_unknown(self) -> None:
+        """Test checking replies with unknown text."""
+        hook = SlackApprovalHook()
+        replies = [{"text": "maybe later", "user": "U12345"}]
+        status, _responder, _feedback = hook._check_replies(replies)
+        assert status is None
+
+    def test_check_replies_no_user(self) -> None:
+        """Test checking replies with no user."""
+        hook = SlackApprovalHook()
+        replies = [{"text": "approve", "user": ""}]
+        status, _responder, _feedback = hook._check_replies(replies)
+        assert status is None
+
+    def test_check_replies_case_insensitive(self) -> None:
+        """Test checking replies is case insensitive."""
+        hook = SlackApprovalHook()
+        replies = [{"text": "APPROVE", "user": "U12345"}]
+        status, _responder, _feedback = hook._check_replies(replies)
+        assert status == ApprovalStatus.APPROVED
+
+
+class TestApprovalRequest:
+    """Tests for ApprovalRequest dataclass."""
+
+    def test_default_values(self) -> None:
+        """Test ApprovalRequest has correct defaults."""
+        request = ApprovalRequest(
+            id="abc123",
+            channel="C12345",
+            message="Test message",
+        )
+        assert request.status == ApprovalStatus.PENDING
+        assert request.responded_at is None
+        assert request.responder is None
+        assert request.feedback is None
+
+
+class TestApprovalStatus:
+    """Tests for ApprovalStatus enum."""
+
+    def test_status_values(self) -> None:
+        """Test status enum values."""
+        assert ApprovalStatus.PENDING == "pending"
+        assert ApprovalStatus.APPROVED == "approved"
+        assert ApprovalStatus.REJECTED == "rejected"
+        assert ApprovalStatus.EXPIRED == "expired"
+
+
+class TestSlackApprovalHookIntegration:
+    """Integration tests that mock the Slack API."""
+
+    @pytest.mark.asyncio
+    async def test_send_notification_success(self) -> None:
+        """Test sending notification successfully."""
+        hook = SlackApprovalHook(channel="#test-channel", token="test-token")
+
+        with patch.object(SlackClient, "post_message", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = {"ok": True, "ts": "123.456"}
+
+            result = await hook.send_notification(
+                "Test notification",
+                context={"key": "value"},
+                level="info",
+            )
+
+            assert result is True
+            mock_post.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_send_notification_failure(self) -> None:
+        """Test sending notification when it fails."""
+        hook = SlackApprovalHook(channel="#test-channel", token="test-token")
+
+        with patch.object(SlackClient, "post_message", new_callable=AsyncMock) as mock_post:
+            mock_post.side_effect = RuntimeError("API Error")
+
+            result = await hook.send_notification("Test notification")
+
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_send_notification_different_levels(self) -> None:
+        """Test sending notifications with different levels."""
+        hook = SlackApprovalHook(channel="#test-channel", token="test-token")
+
+        levels = ["info", "warning", "error", "success"]
+
+        for level in levels:
+            with patch.object(SlackClient, "post_message", new_callable=AsyncMock) as mock_post:
+                mock_post.return_value = {"ok": True, "ts": "123.456"}
+
+                result = await hook.send_notification(
+                    f"Test {level}",
+                    level=level,
+                )
+
+                assert result is True
+
+
+@pytest.mark.skipif(
+    not os.environ.get("SLACK_BOT_TOKEN"),
+    reason="SLACK_BOT_TOKEN not set - skipping real Slack integration tests",
+)
+class TestSlackRealIntegration:
+    """Real integration tests with Slack.
+
+    These tests only run when SLACK_BOT_TOKEN is set.
+    They test actual API connectivity.
+    """
+
+    @pytest.mark.asyncio
+    async def test_auth_test(self) -> None:
+        """Test Slack authentication."""
+        async with SlackClient() as client:
+            result = await client.test_auth()
+            assert result is not None
+            assert result.get("ok") is True
+
+    @pytest.mark.asyncio
+    async def test_post_and_get_reactions(self) -> None:
+        """Test posting a message and getting reactions."""
+        channel = os.environ.get("SLACK_CHANNEL", "#game-dev-test")
+
+        async with SlackClient() as client:
+            # Post a test message
+            result = await client.post_message(
+                channel=channel,
+                text="Integration test message (will be deleted)",
+            )
+
+            assert result.get("ok") is True
+            ts = result.get("ts")
+            assert ts is not None
+
+            # Get reactions (should be empty initially)
+            reactions = await client.get_reactions(result.get("channel"), ts)
+            assert isinstance(reactions, list)

--- a/tests/unit/test_mcp_servers.py
+++ b/tests/unit/test_mcp_servers.py
@@ -1,7 +1,98 @@
 """Tests for the MCP servers module."""
 
-from game_workflow.mcp_servers import MCPServerRegistry
-from game_workflow.mcp_servers.itchio import ButlerCLI
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from game_workflow.mcp_servers import MCPServerConfig, MCPServerProcess, MCPServerRegistry
+from game_workflow.mcp_servers.itchio import (
+    APIResponse,
+    ButlerCLI,
+    ButlerPushResult,
+    ButlerStatusResult,
+    ButlerVersion,
+    GameClassification,
+    GameType,
+    ItchioAPI,
+    ItchioGame,
+    ItchioUpload,
+    ItchioUser,
+)
+
+
+class TestMCPServerConfig:
+    """Tests for MCPServerConfig dataclass."""
+
+    def test_config_defaults(self) -> None:
+        """Test config has sensible defaults."""
+        config = MCPServerConfig(command="python")
+        assert config.command == "python"
+        assert config.args == []
+        assert config.env == {}
+        assert config.working_dir is None
+        assert config.startup_timeout == 30.0
+        assert config.health_check_interval == 10.0
+
+    def test_config_with_all_fields(self) -> None:
+        """Test config with all fields set."""
+        config = MCPServerConfig(
+            command="node",
+            args=["server.js"],
+            env={"PORT": "3000"},
+            working_dir="/app",
+            startup_timeout=60.0,
+            health_check_interval=5.0,
+        )
+        assert config.command == "node"
+        assert config.args == ["server.js"]
+        assert config.env == {"PORT": "3000"}
+        assert config.working_dir == "/app"
+        assert config.startup_timeout == 60.0
+        assert config.health_check_interval == 5.0
+
+
+class TestMCPServerProcess:
+    """Tests for MCPServerProcess dataclass."""
+
+    def test_is_running_no_process(self) -> None:
+        """Test is_running returns False when no process."""
+        config = MCPServerConfig(command="python")
+        proc = MCPServerProcess(name="test", config=config)
+        assert proc.is_running is False
+
+    def test_is_running_with_active_process(self) -> None:
+        """Test is_running returns True when process is active."""
+        config = MCPServerConfig(command="python")
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None  # None means still running
+        proc = MCPServerProcess(name="test", config=config, process=mock_process)
+        assert proc.is_running is True
+
+    def test_is_running_with_terminated_process(self) -> None:
+        """Test is_running returns False when process has exited."""
+        config = MCPServerConfig(command="python")
+        mock_process = MagicMock()
+        mock_process.poll.return_value = 0  # Exit code means not running
+        proc = MCPServerProcess(name="test", config=config, process=mock_process)
+        assert proc.is_running is False
+
+    def test_pid_no_process(self) -> None:
+        """Test pid returns None when no process."""
+        config = MCPServerConfig(command="python")
+        proc = MCPServerProcess(name="test", config=config)
+        assert proc.pid is None
+
+    def test_pid_with_running_process(self) -> None:
+        """Test pid returns process ID when running."""
+        config = MCPServerConfig(command="python")
+        mock_process = MagicMock()
+        mock_process.poll.return_value = None
+        mock_process.pid = 12345
+        proc = MCPServerProcess(name="test", config=config, process=mock_process)
+        assert proc.pid == 12345
 
 
 class TestMCPServerRegistry:
@@ -29,6 +120,142 @@ class TestMCPServerRegistry:
         result = registry.get("nonexistent")
         assert result is None
 
+    def test_register_custom_server(self) -> None:
+        """Test registering a custom server."""
+        registry = MCPServerRegistry()
+        config = MCPServerConfig(command="python", args=["custom_server.py"])
+        registry.register("custom", config)
+        assert "custom" in registry.list_servers()
+        assert registry.get("custom") == config
+
+    def test_unregister_server(self) -> None:
+        """Test unregistering a server."""
+        registry = MCPServerRegistry()
+        config = MCPServerConfig(command="python")
+        registry.register("custom", config)
+        assert "custom" in registry.list_servers()
+        result = registry.unregister("custom")
+        assert result is True
+        assert "custom" not in registry.list_servers()
+
+    def test_unregister_nonexistent(self) -> None:
+        """Test unregistering a nonexistent server returns False."""
+        registry = MCPServerRegistry()
+        result = registry.unregister("nonexistent")
+        assert result is False
+
+    def test_list_running_empty(self) -> None:
+        """Test list_running returns empty list when nothing running."""
+        registry = MCPServerRegistry()
+        assert registry.list_running() == []
+
+    def test_is_running_false_when_not_started(self) -> None:
+        """Test is_running returns False for unstarted server."""
+        registry = MCPServerRegistry()
+        assert registry.is_running("github") is False
+
+    def test_is_healthy_false_when_not_started(self) -> None:
+        """Test is_healthy returns False for unstarted server."""
+        registry = MCPServerRegistry()
+        assert registry.is_healthy("github") is False
+
+    def test_get_process_none_when_not_started(self) -> None:
+        """Test get_process returns None for unstarted server."""
+        registry = MCPServerRegistry()
+        assert registry.get_process("github") is None
+
+    def test_get_server_stats_none_when_not_started(self) -> None:
+        """Test get_server_stats returns None for unstarted server."""
+        registry = MCPServerRegistry()
+        assert registry.get_server_stats("github") is None
+
+    def test_get_all_stats(self) -> None:
+        """Test get_all_stats returns dict for all servers."""
+        registry = MCPServerRegistry()
+        stats = registry.get_all_stats()
+        assert "github" in stats
+        assert "slack" in stats
+        assert "itchio" in stats
+
+
+class TestButlerVersion:
+    """Tests for ButlerVersion dataclass."""
+
+    def test_from_output_simple(self) -> None:
+        """Test parsing simple version output."""
+        output = "butler version 15.21.0"
+        version = ButlerVersion.from_output(output)
+        assert version.version == "15.21.0"
+
+    def test_from_output_with_built_at(self) -> None:
+        """Test parsing version with build date."""
+        output = "butler version 15.21.0, built on 2024-01-15"
+        version = ButlerVersion.from_output(output)
+        assert version.version == "15.21.0"
+        assert version.built_at == "2024-01-15"
+
+    def test_from_output_with_commit(self) -> None:
+        """Test parsing version with commit hash."""
+        output = "butler version 15.21.0\ncommit abc123"
+        version = ButlerVersion.from_output(output)
+        assert version.version == "15.21.0"
+        assert version.commit == "abc123"
+
+    def test_from_output_empty(self) -> None:
+        """Test parsing empty output."""
+        version = ButlerVersion.from_output("")
+        assert version.version == "unknown"
+
+
+class TestButlerPushResult:
+    """Tests for ButlerPushResult dataclass."""
+
+    def test_success_result(self) -> None:
+        """Test successful push result."""
+        result = ButlerPushResult(
+            success=True,
+            target="user/game",
+            channel="html5",
+            version="1.0.0",
+            build_id=12345,
+        )
+        assert result.success is True
+        assert result.target == "user/game"
+        assert result.channel == "html5"
+        assert result.version == "1.0.0"
+        assert result.build_id == 12345
+        assert result.error is None
+
+    def test_failure_result(self) -> None:
+        """Test failed push result."""
+        result = ButlerPushResult(
+            success=False,
+            target="user/game",
+            channel="html5",
+            error="Upload failed",
+        )
+        assert result.success is False
+        assert result.error == "Upload failed"
+
+
+class TestButlerStatusResult:
+    """Tests for ButlerStatusResult dataclass."""
+
+    def test_success_result(self) -> None:
+        """Test successful status result."""
+        result = ButlerStatusResult(
+            success=True,
+            target="user/game",
+            channels={"html5": {"version": "1.0.0"}},
+        )
+        assert result.success is True
+        assert result.channels == {"html5": {"version": "1.0.0"}}
+
+    def test_default_channels(self) -> None:
+        """Test default channels is empty dict."""
+        result = ButlerStatusResult(success=True, target="user/game")
+        assert result.channels == {}
+
 
 class TestButlerCLI:
     """Tests for the Butler CLI wrapper."""
@@ -36,9 +263,295 @@ class TestButlerCLI:
     def test_init_default_path(self) -> None:
         """Test Butler initialization with default path."""
         butler = ButlerCLI()
-        assert butler.butler_path == "butler"
+        # Path should be Path type
+        assert butler.butler_path.name == "butler"
 
     def test_init_custom_path(self) -> None:
         """Test Butler initialization with custom path."""
         butler = ButlerCLI("/usr/local/bin/butler")
-        assert butler.butler_path == "/usr/local/bin/butler"
+        assert butler.butler_path == Path("/usr/local/bin/butler")
+
+    def test_init_custom_timeout(self) -> None:
+        """Test Butler initialization with custom timeout."""
+        butler = ButlerCLI(timeout=600.0)
+        assert butler.timeout == 600.0
+
+    def test_check_installed_not_found(self) -> None:
+        """Test check_installed returns False when not installed."""
+        butler = ButlerCLI("/nonexistent/butler")
+        assert butler.check_installed() is False
+
+    def test_get_version_not_found(self) -> None:
+        """Test get_version returns None when not installed."""
+        butler = ButlerCLI("/nonexistent/butler")
+        assert butler.get_version() is None
+
+    def test_is_logged_in_not_found(self) -> None:
+        """Test is_logged_in returns False when not installed."""
+        butler = ButlerCLI("/nonexistent/butler")
+        assert butler.is_logged_in() is False
+
+    @patch("platform.system")
+    @patch("platform.machine")
+    def test_get_platform_key_darwin_arm64(
+        self, mock_machine: MagicMock, mock_system: MagicMock
+    ) -> None:
+        """Test platform key for M1 Mac."""
+        mock_system.return_value = "Darwin"
+        mock_machine.return_value = "arm64"
+        key = ButlerCLI._get_platform_key()
+        assert key == "darwin_arm64"
+
+    @patch("platform.system")
+    @patch("platform.machine")
+    def test_get_platform_key_darwin_x64(
+        self, mock_machine: MagicMock, mock_system: MagicMock
+    ) -> None:
+        """Test platform key for Intel Mac."""
+        mock_system.return_value = "Darwin"
+        mock_machine.return_value = "x86_64"
+        key = ButlerCLI._get_platform_key()
+        assert key == "darwin_x64"
+
+    @patch("platform.system")
+    @patch("platform.machine")
+    def test_get_platform_key_linux(
+        self, mock_machine: MagicMock, mock_system: MagicMock
+    ) -> None:
+        """Test platform key for Linux."""
+        mock_system.return_value = "Linux"
+        mock_machine.return_value = "x86_64"
+        key = ButlerCLI._get_platform_key()
+        assert key == "linux_x64"
+
+    @patch("platform.system")
+    @patch("platform.machine")
+    def test_get_platform_key_windows(
+        self, mock_machine: MagicMock, mock_system: MagicMock
+    ) -> None:
+        """Test platform key for Windows."""
+        mock_system.return_value = "Windows"
+        mock_machine.return_value = "AMD64"
+        key = ButlerCLI._get_platform_key()
+        assert key == "windows_x64"
+
+    @pytest.mark.asyncio
+    async def test_push_directory_not_exists(self, tmp_path: Path) -> None:
+        """Test push fails when directory doesn't exist."""
+        butler = ButlerCLI()
+        result = await butler.push(
+            directory=tmp_path / "nonexistent",
+            target="user/game",
+            channel="html5",
+        )
+        assert result.success is False
+        assert "does not exist" in result.error
+
+    @pytest.mark.asyncio
+    async def test_push_not_directory(self, tmp_path: Path) -> None:
+        """Test push fails when path is not a directory."""
+        file_path = tmp_path / "file.txt"
+        file_path.touch()
+        butler = ButlerCLI()
+        result = await butler.push(
+            directory=file_path,
+            target="user/game",
+            channel="html5",
+        )
+        assert result.success is False
+        assert "not a directory" in result.error
+
+    @pytest.mark.asyncio
+    async def test_validate_empty_directory(self, tmp_path: Path) -> None:
+        """Test validate fails for empty directory."""
+        butler = ButlerCLI()
+        is_valid, message = await butler.validate(tmp_path)
+        assert is_valid is False
+        assert "empty" in message.lower()
+
+    @pytest.mark.asyncio
+    async def test_validate_with_index_html(self, tmp_path: Path) -> None:
+        """Test validate succeeds for HTML5 game."""
+        (tmp_path / "index.html").touch()
+        butler = ButlerCLI()
+        is_valid, message = await butler.validate(tmp_path)
+        assert is_valid is True
+        assert "HTML5" in message
+
+    @pytest.mark.asyncio
+    async def test_validate_with_other_files(self, tmp_path: Path) -> None:
+        """Test validate succeeds for directory with files."""
+        (tmp_path / "game.exe").touch()
+        butler = ButlerCLI()
+        is_valid, message = await butler.validate(tmp_path)
+        assert is_valid is True
+        assert "contains files" in message
+
+
+class TestItchioGame:
+    """Tests for ItchioGame dataclass."""
+
+    def test_from_dict_minimal(self) -> None:
+        """Test creating game from minimal dict."""
+        game = ItchioGame.from_dict({
+            "id": 12345,
+            "url": "https://user.itch.io/game",
+            "title": "My Game",
+        })
+        assert game.id == 12345
+        assert game.url == "https://user.itch.io/game"
+        assert game.title == "My Game"
+        assert game.type == GameType.DEFAULT
+        assert game.classification == GameClassification.GAME
+
+    def test_from_dict_full(self) -> None:
+        """Test creating game from full dict."""
+        game = ItchioGame.from_dict({
+            "id": 12345,
+            "url": "https://user.itch.io/game",
+            "title": "My Game",
+            "short_text": "A great game",
+            "type": "html",
+            "classification": "tool",
+            "downloads_count": 100,
+            "views_count": 1000,
+            "p_windows": True,
+        })
+        assert game.short_text == "A great game"
+        assert game.type == GameType.HTML
+        assert game.classification == GameClassification.TOOL
+        assert game.downloads_count == 100
+        assert game.views_count == 1000
+        assert game.p_windows is True
+
+    def test_from_dict_unknown_type(self) -> None:
+        """Test creating game with unknown type falls back to default."""
+        game = ItchioGame.from_dict({
+            "id": 12345,
+            "url": "https://user.itch.io/game",
+            "title": "My Game",
+            "type": "unknown_type",
+        })
+        assert game.type == GameType.DEFAULT
+
+
+class TestItchioUpload:
+    """Tests for ItchioUpload dataclass."""
+
+    def test_from_dict(self) -> None:
+        """Test creating upload from dict."""
+        upload = ItchioUpload.from_dict({
+            "id": 1,
+            "game_id": 12345,
+            "filename": "game.zip",
+            "size": 1024000,
+            "channel_name": "html5",
+        })
+        assert upload.id == 1
+        assert upload.game_id == 12345
+        assert upload.filename == "game.zip"
+        assert upload.size == 1024000
+        assert upload.channel_name == "html5"
+
+
+class TestItchioUser:
+    """Tests for ItchioUser dataclass."""
+
+    def test_from_dict(self) -> None:
+        """Test creating user from dict."""
+        user = ItchioUser.from_dict({
+            "id": 123,
+            "username": "testuser",
+            "url": "https://testuser.itch.io",
+            "display_name": "Test User",
+            "developer": True,
+        })
+        assert user.id == 123
+        assert user.username == "testuser"
+        assert user.url == "https://testuser.itch.io"
+        assert user.display_name == "Test User"
+        assert user.developer is True
+
+
+class TestAPIResponse:
+    """Tests for APIResponse dataclass."""
+
+    def test_from_response_success(self) -> None:
+        """Test creating response from successful HTTP response."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {"user": {"id": 123}}
+
+        response = APIResponse.from_response(mock_response)
+        assert response.success is True
+        assert response.data == {"user": {"id": 123}}
+        assert response.error is None
+
+    def test_from_response_with_errors(self) -> None:
+        """Test creating response with API errors."""
+        mock_response = MagicMock()
+        mock_response.is_success = True
+        mock_response.json.return_value = {"errors": ["Invalid API key"]}
+
+        response = APIResponse.from_response(mock_response)
+        assert response.success is False
+        assert response.error == "Invalid API key"
+        assert response.errors == ["Invalid API key"]
+
+    def test_from_response_parse_error(self) -> None:
+        """Test creating response when JSON parsing fails."""
+        mock_response = MagicMock()
+        mock_response.json.side_effect = ValueError("Invalid JSON")
+
+        response = APIResponse.from_response(mock_response)
+        assert response.success is False
+        assert "Failed to parse" in response.error
+
+
+class TestItchioAPI:
+    """Tests for ItchioAPI class."""
+
+    def test_init_with_api_key(self) -> None:
+        """Test initialization with API key."""
+        api = ItchioAPI(api_key="test_key")
+        assert api.api_key == "test_key"
+        assert api.timeout == 30.0
+        assert api.max_retries == 3
+
+    def test_init_with_custom_settings(self) -> None:
+        """Test initialization with custom settings."""
+        api = ItchioAPI(
+            api_key="test_key",
+            timeout=60.0,
+            max_retries=5,
+            retry_delay=2.0,
+        )
+        assert api.timeout == 60.0
+        assert api.max_retries == 5
+        assert api.retry_delay == 2.0
+
+    def test_get_key_param(self) -> None:
+        """Test _get_key_param returns correct dict."""
+        api = ItchioAPI(api_key="test_key")
+        assert api._get_key_param() == {"api_key": "test_key"}
+
+    def test_get_key_param_empty(self) -> None:
+        """Test _get_key_param returns empty dict when no key."""
+        api = ItchioAPI(api_key="")
+        assert api._get_key_param() == {}
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self) -> None:
+        """Test async context manager creates and closes client."""
+        async with ItchioAPI(api_key="test_key") as api:
+            assert api._client is not None
+        assert api._client is None
+
+    @pytest.mark.asyncio
+    async def test_client_property_creates_client(self) -> None:
+        """Test client property creates client if needed."""
+        api = ItchioAPI(api_key="test_key")
+        assert api._client is None
+        _ = api.client  # Access property
+        assert api._client is not None
+        await api.close()


### PR DESCRIPTION
## Summary

This PR implements Phase 6 of the implementation plan: MCP Servers.

### Changes

- **MCP Server Registry (6.1)**: Added lifecycle management for MCP servers with start/stop/restart and health checking
- **Butler CLI Wrapper (6.2)**: Created Python wrapper for butler CLI for itch.io uploads
- **itch.io API Client (6.3)**: Implemented async API client with retry logic and rate limiting
- **itch.io MCP Server (6.4)**: Created MCP protocol server with upload_game, get_game_status, get_my_games, check_credentials tools
- **Slack Approval Hook (6.5)**: Implemented human-in-the-loop approval via Slack with reaction/reply-based responses
- **Unit Tests (6.6)**: Added 56 unit tests for MCP servers
- **Integration Tests (6.7)**: Added 37 integration tests for Slack hook

### Stats

- **Files changed**: 11
- **Lines added**: ~3,500
- **Tests**: 294 total (all passing)

## Test plan

- [x] All unit tests pass: `pytest tests/unit/test_mcp_servers.py -v`
- [x] All integration tests pass: `pytest tests/integration/test_slack_integration.py -v`
- [x] Full test suite passes: `pytest tests/ -v`
- [x] Linting passes: `ruff check src/ tests/`

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)