### PR TITLE
test(integration): add comprehensive integration tests for external services

### DIFF
--- a/tests/integration/test_approval_flows.py
+++ b/tests/integration/test_approval_flows.py
@@ -39,11 +39,13 @@ class AlwaysApproveHook:
         context: dict[str, Any] | None = None,
         timeout_minutes: int | None = None,
     ) -> bool:
-        self.requests.append({
-            "message": message,
-            "context": context,
-            "timeout_minutes": timeout_minutes,
-        })
+        self.requests.append(
+            {
+                "message": message,
+                "context": context,
+                "timeout_minutes": timeout_minutes,
+            }
+        )
         return True
 
     async def send_notification(
@@ -53,11 +55,13 @@ class AlwaysApproveHook:
         context: dict[str, Any] | None = None,
         level: str = "info",
     ) -> bool:
-        self.notifications.append({
-            "message": message,
-            "context": context,
-            "level": level,
-        })
+        self.notifications.append(
+            {
+                "message": message,
+                "context": context,
+                "level": level,
+            }
+        )
         return True
 
 
@@ -74,11 +78,13 @@ class AlwaysRejectHook:
         context: dict[str, Any] | None = None,
         timeout_minutes: int | None = None,
     ) -> bool:
-        self.requests.append({
-            "message": message,
-            "context": context,
-            "timeout_minutes": timeout_minutes,
-        })
+        self.requests.append(
+            {
+                "message": message,
+                "context": context,
+                "timeout_minutes": timeout_minutes,
+            }
+        )
         return False
 
     async def send_notification(
@@ -88,11 +94,13 @@ class AlwaysRejectHook:
         context: dict[str, Any] | None = None,
         level: str = "info",
     ) -> bool:
-        self.notifications.append({
-            "message": message,
-            "context": context,
-            "level": level,
-        })
+        self.notifications.append(
+            {
+                "message": message,
+                "context": context,
+                "level": level,
+            }
+        )
         return True
 
 
@@ -115,11 +123,13 @@ class SelectiveApprovalHook:
         context: dict[str, Any] | None = None,
         timeout_minutes: int | None = None,
     ) -> bool:
-        self.requests.append({
-            "message": message,
-            "context": context,
-            "timeout_minutes": timeout_minutes,
-        })
+        self.requests.append(
+            {
+                "message": message,
+                "context": context,
+                "timeout_minutes": timeout_minutes,
+            }
+        )
 
         # Check against reject gates first
         for gate in self.reject_gates:
@@ -141,11 +151,13 @@ class SelectiveApprovalHook:
         context: dict[str, Any] | None = None,
         level: str = "info",
     ) -> bool:
-        self.notifications.append({
-            "message": message,
-            "context": context,
-            "level": level,
-        })
+        self.notifications.append(
+            {
+                "message": message,
+                "context": context,
+                "level": level,
+            }
+        )
         return True
 
 
@@ -164,11 +176,13 @@ class TimeoutApprovalHook:
         context: dict[str, Any] | None = None,
         timeout_minutes: int | None = None,
     ) -> bool:
-        self.requests.append({
-            "message": message,
-            "context": context,
-            "timeout_minutes": timeout_minutes,
-        })
+        self.requests.append(
+            {
+                "message": message,
+                "context": context,
+                "timeout_minutes": timeout_minutes,
+            }
+        )
         self.request_count += 1
 
         if self.request_count > self.timeout_after:
@@ -184,11 +198,13 @@ class TimeoutApprovalHook:
         context: dict[str, Any] | None = None,
         level: str = "info",
     ) -> bool:
-        self.notifications.append({
-            "message": message,
-            "context": context,
-            "level": level,
-        })
+        self.notifications.append(
+            {
+                "message": message,
+                "context": context,
+                "level": level,
+            }
+        )
         return True
 
 
@@ -206,11 +222,13 @@ class DelayedApprovalHook:
         context: dict[str, Any] | None = None,
         timeout_minutes: int | None = None,
     ) -> bool:
-        self.requests.append({
-            "message": message,
-            "context": context,
-            "timeout_minutes": timeout_minutes,
-        })
+        self.requests.append(
+            {
+                "message": message,
+                "context": context,
+                "timeout_minutes": timeout_minutes,
+            }
+        )
         await asyncio.sleep(self.delay_seconds)
         return True
 
@@ -221,11 +239,13 @@ class DelayedApprovalHook:
         context: dict[str, Any] | None = None,
         level: str = "info",
     ) -> bool:
-        self.notifications.append({
-            "message": message,
-            "context": context,
-            "level": level,
-        })
+        self.notifications.append(
+            {
+                "message": message,
+                "context": context,
+                "level": level,
+            }
+        )
         return True
 
 

--- a/tests/integration/test_error_scenarios.py
+++ b/tests/integration/test_error_scenarios.py
@@ -64,11 +64,13 @@ class MockApprovalHook:
         context: dict[str, Any] | None = None,
         timeout_minutes: int | None = None,
     ) -> bool:
-        self.requests.append({
-            "message": message,
-            "context": context,
-            "timeout_minutes": timeout_minutes,
-        })
+        self.requests.append(
+            {
+                "message": message,
+                "context": context,
+                "timeout_minutes": timeout_minutes,
+            }
+        )
         return True
 
     async def send_notification(
@@ -78,11 +80,13 @@ class MockApprovalHook:
         context: dict[str, Any] | None = None,
         level: str = "info",
     ) -> bool:
-        self.notifications.append({
-            "message": message,
-            "context": context,
-            "level": level,
-        })
+        self.notifications.append(
+            {
+                "message": message,
+                "context": context,
+                "level": level,
+            }
+        )
         return True
 
 

--- a/tests/integration/test_external_services.py
+++ b/tests/integration/test_external_services.py
@@ -40,8 +40,6 @@ def sample_prompt() -> str:
     return "Create a simple puzzle game where players match colored blocks."
 
 
-
-
 @pytest.fixture
 def mock_itchio_api() -> MagicMock:
     """Create a mock itch.io API client."""
@@ -65,7 +63,9 @@ def mock_itchio_api() -> MagicMock:
     api.get_game = AsyncMock(
         return_value=APIResponse(
             success=True,
-            data={"game": {"id": 1, "title": "Test Game", "url": "https://testuser.itch.io/test-game"}},
+            data={
+                "game": {"id": 1, "title": "Test Game", "url": "https://testuser.itch.io/test-game"}
+            },
         )
     )
     return api
@@ -421,9 +421,7 @@ class TestWorkflowWithExternalServices:
                 context: dict[str, Any] | None = None,
                 level: str = "info",
             ) -> bool:
-                notifications.append(
-                    {"message": message, "context": context, "level": level}
-                )
+                notifications.append({"message": message, "context": context, "level": level})
                 return True
 
         # Create a mock GDD file


### PR DESCRIPTION
## Summary
- Add integration tests for mocked external services (GitHub, Slack, itch.io)
- Add tests for all approval paths (approve, reject, timeout, selective)
- Add tests for error scenarios (agent failures, API errors, timeouts)
- Add tests for error recovery mechanisms

## Test Coverage

### External Services Tests (`test_external_services.py` - 21 tests)
- Slack approval blocks creation and reaction/reply checking
- itch.io API mocking (profile, games, error handling)
- MCP server registry configuration
- GitHub release metadata generation
- Workflow with external service notifications

### Approval Flow Tests (`test_approval_flows.py` - 16 tests)
- All approvals granted
- Concept/build/publish rejection
- Approval timeout handling
- Selective approval gates
- Auto-approval mode
- No-hook behavior
- Notification tracking

### Error Scenario Tests (`test_error_scenarios.py` - 24 tests)
- Agent failures (Design, Build, QA, Publish)
- API errors (rate limits, auth failures, network errors)
- Timeout handling
- Retry logic (success after failure, exhaustion)
- Error recovery (cancel, rollback, phase retry)
- State persistence after errors
- Hook error isolation

## Test Results
All 373 tests pass (61 new integration tests + 312 existing)

## Closes
Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)